### PR TITLE
feat: Add KubernetesConfig with image field to deployment

### DIFF
--- a/schema/v1/schema.json
+++ b/schema/v1/schema.json
@@ -297,7 +297,8 @@
           "type": "string",
           "enum": ["kubernetes", "cloudrun"]
         },
-        "cloudrun": { "$ref": "#/definitions/CloudRunConfig" }
+        "cloudrun": { "$ref": "#/definitions/CloudRunConfig" },
+        "kubernetes": { "$ref": "#/definitions/KubernetesConfig" }
       }
     },
     "CloudRunConfig": {
@@ -311,6 +312,12 @@
           "type": "object",
           "additionalProperties": { "type": "string" }
         }
+      }
+    },
+    "KubernetesConfig": {
+      "type": "object",
+      "properties": {
+        "image": { "$ref": "#/definitions/ImageConfig" }
       }
     },
     "ImageConfig": {


### PR DESCRIPTION
## Summary

- Adds `spec.deployment.kubernetes` to the ADL v1 schema, mirroring the existing `spec.deployment.cloudrun` shape so manifests targeting Kubernetes can specify a container registry, repository, and tag in a structured way (instead of downstream consumers having to synthesize the image string from `metadata.name` + `metadata.version`).
- Reuses the existing `ImageConfig` definition; `useCloudBuild` is meaningless for Kubernetes and is simply ignored by k8s-aware consumers.
- Motivated by [`adl-cli`](https://github.com/inference-gateway/adl-cli)'s `k8s/deployment.yaml` template, which currently hardcodes `{name}:{version}` with no registry prefix. Once this lands and `adl-cli` bumps `ADL_SCHEMA_VERSION`, the template can render `{registry}/{repository}:{tag}` from manifest data.

## Backwards compatibility

Purely additive within `schema/v1/`: `kubernetes` is optional, and existing manifests that don't set it remain valid. Verified locally against `adl-cli`'s `examples/cloudrun-agent.yaml`, `examples/kubernetes-agent.yaml`, and `examples/go-agent.yaml` — all still validate against the updated schema.