### PR TITLE
feat: Split tools and skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,16 @@ A declarative language for defining AI agents, their capabilities, and skills. T
 
 ## What is ADL?
 
-ADL (Agent Definition Language) is a vendor-neutral, declarative specification for AI agents. Just as OpenAPI provides a standard way to describe REST services, ADL provides a standard way to describe agents: their metadata, capabilities, skills, the AI provider behind them, the services they depend on, and the runtime they ship to.
+ADL (Agent Definition Language) is a vendor-neutral, declarative specification for AI agents. Just as OpenAPI provides a standard way to describe REST services, ADL provides a standard way to describe agents: their metadata, capabilities, tools, skills, the AI provider behind them, the services they depend on, and the runtime they ship to.
 
 This repository is the **source of truth for the ADL schema**. The JSON Schema document under [`schema/v1/schema.json`](./schema/v1/schema.json) is the canonical specification. Tools that produce or consume ADL manifests (including [`adl-cli`](https://github.com/inference-gateway/adl-cli)) pin to a tagged version of this schema.
+
+### Tools vs Skills
+
+ADL distinguishes two ways for an agent to act:
+
+- **Tools** (`spec.tools[]`) are function-call entrypoints. Each tool has a JSON Schema for its inputs and is generated as code in the target language. Use a tool when the agent needs to invoke a deterministic operation (query a database, send an email, call an API).
+- **Skills** (`spec.skills[]`) are markdown playbooks injected into the agent's system prompt at startup. They're either pulled from the skills registry or scaffolded blank with `bare: true`. Use a skill when you want to teach the agent a workflow, policy, or response pattern in natural language.
 
 ## Layout
 
@@ -59,7 +66,7 @@ spec:
       You are a professional customer support agent.
     maxTokens: 4096
     temperature: 0.3
-  skills:
+  tools:
     - id: knowledge_search
       name: knowledge_search
       description: Search the company knowledge base
@@ -74,6 +81,14 @@ spec:
             description: The search query
         required:
           - query
+  skills:
+    - id: incident-response
+      bare: true
+      name: incident-response
+      description: How to triage a paged production incident, draft an initial response, and notify stakeholders.
+      tags:
+        - operations
+        - incident
   server:
     port: 8080
     debug: false

--- a/schema/v1/schema.json
+++ b/schema/v1/schema.json
@@ -55,6 +55,10 @@
           "type": "array",
           "items": { "type": "string" }
         },
+        "tools": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/Tool" }
+        },
         "skills": {
           "type": "array",
           "items": { "$ref": "#/definitions/Skill" }
@@ -134,9 +138,11 @@
         "description": { "type": "string" }
       }
     },
-    "Skill": {
+    "Tool": {
       "type": "object",
+      "description": "Function-call entrypoint the agent can invoke. Generated as code in the target language.",
       "required": ["id", "name", "description", "tags", "schema"],
+      "additionalProperties": false,
       "properties": {
         "id": {
           "type": "string",
@@ -148,30 +154,38 @@
           "type": "array",
           "items": { "type": "string" }
         },
-        "examples": {
-          "type": "array",
-          "items": { "type": "string" }
-        },
-        "inputModes": {
-          "type": "array",
-          "items": { "type": "string" }
-        },
-        "outputModes": {
-          "type": "array",
-          "items": { "type": "string" }
-        },
         "schema": {
           "type": "object",
-          "description": "Free-form JSON Schema describing the skill's input parameters.",
+          "description": "Free-form JSON Schema describing the tool's input parameters.",
           "additionalProperties": true
         },
-        "implementation": { "type": "string" },
         "inject": {
           "type": "array",
           "items": {
             "type": "string",
             "pattern": "^[a-zA-Z_][a-zA-Z0-9_]*(\\.[a-zA-Z_][a-zA-Z0-9_]*)*$"
           }
+        }
+      }
+    },
+    "Skill": {
+      "type": "object",
+      "description": "Markdown playbook injected into the agent's system prompt. Pulled from the skills registry or scaffolded blank with bare: true.",
+      "required": ["id"],
+      "additionalProperties": false,
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^[a-zA-Z0-9_][a-zA-Z0-9_-]*$"
+        },
+        "version": { "type": "string" },
+        "source": { "type": "string" },
+        "bare": { "type": "boolean" },
+        "name": { "type": "string" },
+        "description": { "type": "string" },
+        "tags": {
+          "type": "array",
+          "items": { "type": "string" }
         }
       }
     },


### PR DESCRIPTION
## Summary

- Add `Tool` definition and `spec.tools[]` for function-call entrypoints. `Tool` carries `id`, `name`, `description`, `tags`, `schema` (JSON Schema for inputs), and optional `inject`. `additionalProperties: false`.
- Redefine `Skill` as a markdown playbook. Required is just `["id"]`; optional `version`, `source`, `bare`, `name`, `description`, `tags`. `additionalProperties: false`. The `id` pattern allows hyphens.
- Update README to show the tools/skills split and replace the example manifest accordingly.

## Why

The downstream consumer (`adl-cli`, branch `feat/rearchitect-skills-and-tools`) treats the two concepts separately: tools are generated as code in the target language, skills are markdown documents prepended to the system prompt at startup. Modeling both first-class in the schema removes the ambiguity that came from overloading the previous `Skill` definition.

## Compatibility

This is a breaking change to v1 against v0.2.0 — manifests that used the previous function-call shape under `spec.skills` will not validate (those entries belong under `spec.tools` now, and a few unused fields are dropped). The project is pre-1.0 and the only released consumer is adl-cli, which is updating in the same cycle.

## Test plan

- [x] `task compile` passes against the updated schema
- [x] All nine `adl-cli/examples/*.yaml` manifests validate
- [x] Consumer follow-up wired up on adl-cli (`feat/rearchitect-skills-and-tools`): `task ci` and `task examples:test` both green against this schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)