### PR TITLE
feat(schema): Relax Tool.required to id only

### DIFF
--- a/schema/v1/schema.json
+++ b/schema/v1/schema.json
@@ -140,8 +140,8 @@
     },
     "Tool": {
       "type": "object",
-      "description": "Function-call entrypoint the agent can invoke. Generated as code in the target language.",
-      "required": ["id", "name", "description", "tags", "schema"],
+      "description": "Function-call entrypoint the agent can invoke. Generated as code in the target language. User-defined tools require name, description, tags, and schema; reserved built-in IDs (e.g. read, bash, write, edit) may omit them and have those fields supplied by the generator.",
+      "required": ["id"],
       "additionalProperties": false,
       "properties": {
         "id": {


### PR DESCRIPTION
## Summary

Relax `Tool.required` in `schema/v1/schema.json` from `["id", "name", "description", "tags", "schema"]` to `["id"]`. The other fields stay in `properties` but become optional.

## Why

Downstream consumers (specifically `inference-gateway/adl-cli` — see [issue #109](https://github.com/inference-gateway/adl-cli/issues/109)) want to introduce a small set of reserved tool IDs (`read`, `bash`, `write`, `edit`) whose metadata is owned by the generator rather than the user. Today's `required` block forces users to write boilerplate like:

```yaml
tools:
  - id: read
    name: Read              # ignored by generator
    description: "..."      # ignored by generator
    schema: {}              # ignored by generator
    tags: []                # ignored by generator
```

After this change, the same intent is expressed as:

```yaml
tools:
  - id: read
```

## What this does NOT do

- **Does not break backward compatibility.** Every previously-valid manifest is still valid — the change is purely permissive.
- **Does not introduce new fields.** `spec.config` (`additionalProperties: true`) already supports the per-built-in config shape that adl-cli wants to read for `read`/`bash`/`write`/`edit`. No schema additions needed.
- **Does not push enforcement into JSON Schema.** The "user-defined tools must still provide name/description/tags/schema" rule is enforced by the consumer's validator (e.g., `adl-cli`'s `internal/schema/validator.go`), not here.

## Downstream contract

Documented in the new `Tool` description string:

> User-defined tools require name, description, tags, and schema; reserved built-in IDs (e.g. read, bash, write, edit) may omit them and have those fields supplied by the generator.

Each consumer maintains its own reserved-ID list.

## Verification

- [x] `task compile` passes (`ajv compile --spec=draft7`).
- [x] Schema diff is minimal — two lines (description + required array).

## Release plan

Tag as `v0.4.0` after merge. Downstream `inference-gateway/adl-cli` will bump `ADL_SCHEMA_VERSION` in its `Taskfile.yml`, run `task fetch-schema` + `task generate-types`, and ship the reserved-ID built-in tool work on top.

## Test plan

- [ ] Existing CI (`task compile`) green.
- [ ] No downstream manifest fails validation after this change (purely permissive).

🤖 Generated with [Claude Code](https://claude.com/claude-code)