### PR TITLE
feat(schema): Add scm dependabot/ci/cd flags and ai.enabled config

### DIFF
--- a/schema/v1/schema.json
+++ b/schema/v1/schema.json
@@ -69,7 +69,8 @@
         "hooks": { "$ref": "#/definitions/Hooks" },
         "scm": { "$ref": "#/definitions/SCM" },
         "sandbox": { "$ref": "#/definitions/SandboxConfig" },
-        "deployment": { "$ref": "#/definitions/DeploymentConfig" }
+        "deployment": { "$ref": "#/definitions/DeploymentConfig" },
+        "ai": { "$ref": "#/definitions/AIConfig" }
       }
     },
     "Capabilities": {
@@ -272,7 +273,10 @@
         },
         "url": { "type": "string" },
         "github_app": { "type": "boolean" },
-        "issue_templates": { "type": "boolean" }
+        "issue_templates": { "type": "boolean" },
+        "dependabot": { "type": "boolean" },
+        "ci": { "type": "boolean" },
+        "cd": { "type": "boolean" }
       }
     },
     "SandboxConfig": {
@@ -281,6 +285,14 @@
         "flox": { "$ref": "#/definitions/FloxConfig" },
         "devcontainer": { "$ref": "#/definitions/DevContainerConfig" },
         "dockerCompose": { "$ref": "#/definitions/DockerComposeConfig" }
+      }
+    },
+    "AIConfig": {
+      "type": "object",
+      "description": "Toggle generation of AI-assistant documentation (CLAUDE.md, AGENTS.md) and provisioning of claude-code in sandbox environments.",
+      "required": ["enabled"],
+      "properties": {
+        "enabled": { "type": "boolean" }
       }
     },
     "FloxConfig": {


### PR DESCRIPTION
## Summary

Brings `schema/v1/schema.json` in sync with the [adl-cli upstream schema](https://github.com/inference-gateway/adl-cli/blob/main/internal/schema/schema.json) by adding the missing optional fields:

- `spec.scm.dependabot` (boolean)
- `spec.scm.ci` (boolean)
- `spec.scm.cd` (boolean)
- `spec.ai` → `AIConfig` with required `enabled` (boolean)

All additions are backwards-compatible (new optional fields), preserving the v1 additive contract. Defaults of `false` are applied by consumers (adl-cli) when the fields are omitted from a manifest.

After the edit, `diff` against upstream is empty — schemas are byte-for-byte identical.

Closes #5

## Test plan

- [ ] `task compile` passes in CI
- [ ] Sample manifests with and without the new fields validate

🤖 Generated with [Claude Code](https://claude.ai/code)