### PR TITLE
feat(schema)!: Group sandbox and ai under spec.development

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,7 +102,7 @@ spec:
   artifacts:     { enabled }
   hooks:         { post: [commands] }
   scm:           { provider, url, github_app, issue_templates }
-  sandbox:       { flox, devcontainer, dockerCompose }
+  development:   { sandbox: { flox, devcontainer, dockerCompose }, ai: { enabled } }
   deployment:    { type, cloudrun }
 ```
 

--- a/README.md
+++ b/README.md
@@ -96,7 +96,28 @@ spec:
     go:
       module: github.com/company/customer-support-agent
       version: "1.26"
+  development:
+    sandbox:
+      flox:
+        enabled: true
+      devcontainer:
+        enabled: false
+    ai:
+      enabled: true
 ```
+
+### Development sandboxes
+
+`spec.development` groups everything related to the local developer
+experience for an agent project:
+
+- `spec.development.sandbox` selects reproducible dev environments —
+  `flox`, `devcontainer`, or `dockerCompose`. Each is independently
+  toggleable; consumers like `adl-cli` use these flags to scaffold the
+  matching environment files.
+- `spec.development.ai.enabled` toggles generation of AI-assistant
+  documentation (`CLAUDE.md`, `AGENTS.md`) and provisioning of
+  `claude-code` inside the sandbox.
 
 ## Consumers
 

--- a/schema/v1/schema.json
+++ b/schema/v1/schema.json
@@ -68,9 +68,8 @@
         "artifacts": { "$ref": "#/definitions/ArtifactsConfig" },
         "hooks": { "$ref": "#/definitions/Hooks" },
         "scm": { "$ref": "#/definitions/SCM" },
-        "sandbox": { "$ref": "#/definitions/SandboxConfig" },
-        "deployment": { "$ref": "#/definitions/DeploymentConfig" },
-        "ai": { "$ref": "#/definitions/AIConfig" }
+        "development": { "$ref": "#/definitions/DevelopmentConfig" },
+        "deployment": { "$ref": "#/definitions/DeploymentConfig" }
       }
     },
     "Capabilities": {
@@ -279,8 +278,17 @@
         "cd": { "type": "boolean" }
       }
     },
+    "DevelopmentConfig": {
+      "type": "object",
+      "description": "Local development experience for the agent: sandboxed dev environments (flox, devcontainer, dockerCompose) and AI-assistant integration (CLAUDE.md/AGENTS.md generation, claude-code provisioning).",
+      "properties": {
+        "sandbox": { "$ref": "#/definitions/SandboxConfig" },
+        "ai": { "$ref": "#/definitions/AIConfig" }
+      }
+    },
     "SandboxConfig": {
       "type": "object",
+      "description": "Reproducible development environments. flox, devcontainer, and dockerCompose are alternative ways to package the same sandbox; pick what suits the team.",
       "properties": {
         "flox": { "$ref": "#/definitions/FloxConfig" },
         "devcontainer": { "$ref": "#/definitions/DevContainerConfig" },


### PR DESCRIPTION
Closes #7.

## Summary

- Refactor `spec.sandbox` and `spec.ai` into a single `spec.development` namespace with `sandbox` and `ai` subkeys.
- Update `README.md` example to demonstrate the new shape and add a short prose section describing `spec.development`.
- Update `AGENTS.md` spec quick-reference map.

## Breaking change

`spec.sandbox` and `spec.ai` are removed from the v1 schema. Manifests must move these fields under `spec.development.sandbox` and `spec.development.ai` respectively. Per the issue, no backward-compatible alias is provided while the project is pre-stable.

## Test plan

- [ ] `task compile` passes (CI `validate-schema.yml`)
- [ ] A manifest using `spec.development.sandbox` and `spec.development.ai` validates
- [ ] A manifest using the old `spec.sandbox`/`spec.ai` fails validation

Generated with [Claude Code](https://claude.ai/code)