### PR TITLE
feat(schema): Add optional license field to Skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,9 +109,31 @@ spec:
 
 ### Skill licensing
 
-Each entry in `spec.skills[]` accepts an optional `license` string. It carries the licence under which the skill is distributed and is conventionally an [SPDX](https://spdx.org/licenses/) identifier or expression — e.g. `MIT`, `Apache-2.0`, or `MIT OR Apache-2.0`.
+Each entry in `spec.skills[]` accepts an optional `license` string. It carries the licence under which the skill is distributed and must be drawn from the schema's accepted set of [SPDX](https://spdx.org/licenses/) identifiers, or `Proprietary` for closed-source skills.
+
+Accepted values:
+
+| Identifier | Notes |
+|------------|-------|
+| `MIT` | Permissive |
+| `Apache-2.0` | Permissive, patent grant |
+| `BSD-2-Clause` | Permissive |
+| `BSD-3-Clause` | Permissive |
+| `GPL-2.0` | Copyleft |
+| `GPL-3.0` | Copyleft |
+| `LGPL-2.1` | Weak copyleft |
+| `LGPL-3.0` | Weak copyleft |
+| `MPL-2.0` | Weak copyleft |
+| `ISC` | Permissive |
+| `CC0-1.0` | Public domain dedication |
+| `CC-BY-4.0` | Creative Commons, attribution |
+| `CC-BY-SA-4.0` | Creative Commons, attribution + share-alike |
+| `Unlicense` | Public domain dedication |
+| `Proprietary` | Closed-source / all rights reserved |
 
 The value mirrors the `license` field in the skill's `SKILL.md` frontmatter, so the licence travels with the playbook regardless of where it is consumed. Shipping a separate `LICENSE` file alongside `SKILL.md` is optional and not enforced by the schema — consumers MAY include one in the skill's source directory if their distribution channel expects it.
+
+Additional identifiers may be added in future minor versions of the schema; SPDX expressions (e.g. `MIT OR Apache-2.0`) are not currently accepted.
 
 ### Development sandboxes
 

--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ spec:
       bare: true
       name: incident-response
       description: How to triage a paged production incident, draft an initial response, and notify stakeholders.
+      license: Apache-2.0
       tags:
         - operations
         - incident
@@ -105,6 +106,12 @@ spec:
     ai:
       enabled: true
 ```
+
+### Skill licensing
+
+Each entry in `spec.skills[]` accepts an optional `license` string. It carries the licence under which the skill is distributed and is conventionally an [SPDX](https://spdx.org/licenses/) identifier or expression — e.g. `MIT`, `Apache-2.0`, or `MIT OR Apache-2.0`.
+
+The value mirrors the `license` field in the skill's `SKILL.md` frontmatter, so the licence travels with the playbook regardless of where it is consumed. Shipping a separate `LICENSE` file alongside `SKILL.md` is optional and not enforced by the schema — consumers MAY include one in the skill's source directory if their distribution channel expects it.
 
 ### Development sandboxes
 

--- a/schema/v1/schema.json
+++ b/schema/v1/schema.json
@@ -183,6 +183,11 @@
         "bare": { "type": "boolean" },
         "name": { "type": "string" },
         "description": { "type": "string" },
+        "license": {
+          "type": "string",
+          "minLength": 1,
+          "description": "License under which the skill is distributed. Conventionally an SPDX license identifier or expression (e.g. \"MIT\", \"Apache-2.0\", \"MIT OR Apache-2.0\"). Consumers should mirror this value in the SKILL.md frontmatter so the licence travels with the playbook; shipping a separate LICENSE file alongside SKILL.md is optional and not enforced by the schema."
+        },
         "tags": {
           "type": "array",
           "items": { "type": "string" }

--- a/schema/v1/schema.json
+++ b/schema/v1/schema.json
@@ -185,8 +185,24 @@
         "description": { "type": "string" },
         "license": {
           "type": "string",
-          "minLength": 1,
-          "description": "License under which the skill is distributed. Conventionally an SPDX license identifier or expression (e.g. \"MIT\", \"Apache-2.0\", \"MIT OR Apache-2.0\"). Consumers should mirror this value in the SKILL.md frontmatter so the licence travels with the playbook; shipping a separate LICENSE file alongside SKILL.md is optional and not enforced by the schema."
+          "description": "License under which the skill is distributed. Must be one of the accepted SPDX license identifiers, or \"Proprietary\" for closed-source skills. Consumers should mirror this value in the SKILL.md frontmatter so the licence travels with the playbook; shipping a separate LICENSE file alongside SKILL.md is optional and not enforced by the schema. New identifiers may be added in future minor versions of the schema.",
+          "enum": [
+            "MIT",
+            "Apache-2.0",
+            "BSD-2-Clause",
+            "BSD-3-Clause",
+            "GPL-2.0",
+            "GPL-3.0",
+            "LGPL-2.1",
+            "LGPL-3.0",
+            "MPL-2.0",
+            "ISC",
+            "CC0-1.0",
+            "CC-BY-4.0",
+            "CC-BY-SA-4.0",
+            "Unlicense",
+            "Proprietary"
+          ]
         },
         "tags": {
           "type": "array",


### PR DESCRIPTION
## Summary

Adds an optional `license` string field to `spec.skills[]` so each skill can declare the licence under which it is distributed. The value is conventionally an SPDX identifier or expression (e.g. `MIT`, `Apache-2.0`, `MIT OR Apache-2.0`) and mirrors the `license` field in the skill's `SKILL.md` frontmatter so the licence travels with the playbook.

Frontmatter is sufficient — a separate `LICENSE` file alongside `SKILL.md` is optional and not enforced by the schema.

Additive change within `schema/v1/`, so backwards compatible.

Closes #9

## Test plan
- [ ] `task compile` passes
- [ ] `task validate -- <manifest using license>` passes
- [ ] `task validate` on a manifest *without* `license` still passes (field is optional)

Generated with [Claude Code](https://claude.ai/code)