### PR TITLE
feat(schema): Add optional vendor.deps and vendor.devdeps to language configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,11 @@ spec:
     go:
       module: github.com/company/customer-support-agent
       version: "1.26"
+      vendor:
+        deps:
+          - github.com/google/uuid@v1.6.0
+        devdeps:
+          - github.com/stretchr/testify@v1.9.0
   development:
     sandbox:
       flox:
@@ -143,6 +148,60 @@ Accepted values:
 The value mirrors the `license` field in the skill's `SKILL.md` frontmatter, so the licence travels with the playbook regardless of where it is consumed. Shipping a separate `LICENSE` file alongside `SKILL.md` is optional and not enforced by the schema — consumers MAY include one in the skill's source directory if their distribution channel expects it.
 
 Additional identifiers may be added in future minor versions of the schema; SPDX expressions (e.g. `MIT OR Apache-2.0`) are not currently accepted.
+
+### Extra language dependencies
+
+Every language config under `spec.language.<lang>` accepts an optional
+`vendor` block that lets a manifest declare extra packages the
+generator should pull into the project on top of its defaults — useful
+for testing libraries, linters, mock generators, or any runtime
+package the generated scaffolding doesn't ship by default.
+
+- `vendor.deps` — runtime/production dependencies.
+- `vendor.devdeps` — development- and test-only dependencies.
+
+Each entry is a string of the form `<package>@<version>` using the
+target language's native package and version syntax. Consumers (such
+as `adl-cli`) translate these into the language's lockfile / manifest
+format (`go.mod`, `package.json`, `Cargo.toml`, ...).
+
+```yaml
+spec:
+  language:
+    go:
+      module: github.com/company/customer-support-agent
+      version: "1.26"
+      vendor:
+        deps:
+          - github.com/google/uuid@v1.6.0
+        devdeps:
+          - github.com/stretchr/testify@v1.9.0
+          - go.uber.org/mock@v0.4.0
+    typescript:
+      packageName: customer-support-agent
+      nodeVersion: "20"
+      vendor:
+        deps:
+          - zod@3.23.0
+        devdeps:
+          - vitest@1.6.0
+          - "@types/node@20.11.0"
+    rust:
+      packageName: customer-support-agent
+      version: "0.1.0"
+      edition: "2021"
+      vendor:
+        deps:
+          - tokio@1.36.0
+        devdeps:
+          - mockall@0.12.1
+```
+
+Both fields are optional and default to empty. The schema only
+validates the `<package>@<version>` shape — it intentionally does not
+constrain the package or version syntax further, so each language's
+native conventions (Go module paths, npm scoped packages, semver
+ranges, etc.) are accepted.
 
 ### Development sandboxes
 

--- a/schema/v1/schema.json
+++ b/schema/v1/schema.json
@@ -244,7 +244,8 @@
       "required": ["module", "version"],
       "properties": {
         "module": { "type": "string" },
-        "version": { "type": "string" }
+        "version": { "type": "string" },
+        "vendor": { "$ref": "#/definitions/VendorConfig" }
       }
     },
     "TypeScriptConfig": {
@@ -252,7 +253,8 @@
       "required": ["packageName", "nodeVersion"],
       "properties": {
         "packageName": { "type": "string" },
-        "nodeVersion": { "type": "string" }
+        "nodeVersion": { "type": "string" },
+        "vendor": { "$ref": "#/definitions/VendorConfig" }
       }
     },
     "RustConfig": {
@@ -265,6 +267,30 @@
         "features": {
           "type": "array",
           "items": { "type": "string" }
+        },
+        "vendor": { "$ref": "#/definitions/VendorConfig" }
+      }
+    },
+    "VendorConfig": {
+      "type": "object",
+      "description": "Extra packages to vendor into the generated project on top of whatever the generator pulls in by default. Use 'deps' for runtime/production dependencies and 'devdeps' for development- or test-only dependencies (linters, test frameworks, mock generators, etc.). Each entry follows the '<package>@<version>' form using the target language's native package and version syntax (e.g. 'github.com/stretchr/testify@v1.9.0' for Go, 'vitest@1.6.0' or '@types/node@20.11.0' for TypeScript, 'tokio@1.36.0' for Rust). Consumers are responsible for translating these into the language's lockfile / manifest format.",
+      "additionalProperties": false,
+      "properties": {
+        "deps": {
+          "type": "array",
+          "description": "Runtime/production dependencies to add to the generated project, each in '<package>@<version>' form.",
+          "items": {
+            "type": "string",
+            "pattern": "^\\S+@\\S+$"
+          }
+        },
+        "devdeps": {
+          "type": "array",
+          "description": "Development- and test-only dependencies to add to the generated project (e.g. testing libraries, linters, mock generators), each in '<package>@<version>' form.",
+          "items": {
+            "type": "string",
+            "pattern": "^\\S+@\\S+$"
+          }
         }
       }
     },


### PR DESCRIPTION
## Summary

Adds a reusable `VendorConfig` with two optional fields, `deps` and `devdeps`, exposed under `spec.language.{go,typescript,rust}.vendor`. Each entry is a `<package>@<version>` string using the target language's native package syntax (Go module paths, npm scoped packages, Rust crates), letting manifest authors declare extra runtime or test-only dependencies (e.g. testify, vitest, mockall) on top of generator defaults.

Both fields are additive and optional, so existing manifests remain valid and no `apiVersion` bump is needed.

## Changes

- `schema/v1/schema.json`: add `VendorConfig` definition; add optional `vendor` field to `GoConfig`, `TypeScriptConfig`, `RustConfig`.
- `README.md`: document the new `vendor` block ("Extra language dependencies" section) and show it in the example manifest.

The regex `^\S+@\S+$` only enforces the `<package>@<version>` shape; package/version syntax is deliberately delegated to each language's native tooling.

Closes #13

Generated with [Claude Code](https://claude.ai/code)