### PR TITLE
feat: Add spec.development.deps for sandbox-level dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,35 @@ experience for an agent project:
 
   Multiple agents can be enabled at once if a project wants to ship
   configuration for more than one.
+- `spec.development.deps` declares extra packages to install into the
+  development sandbox itself (flox, devcontainer, dockerCompose) on top
+  of whatever the generator pulls in by default. Use this for
+  cross-cutting tools that aren't tied to one of the project's
+  languages — e.g. a Go service that also needs `deno` for quick
+  scripting, or a TypeScript agent that wants `kubectl` available in
+  the dev shell.
+
+  Each entry follows the same `<package>@<version>` shape as
+  `spec.language.<lang>.vendor.deps`:
+
+  ```yaml
+  spec:
+    development:
+      sandbox:
+        flox:
+          enabled: true
+      deps:
+        - deno@2.1.4
+        - kubectl@1.31.0
+        - terraform@1.9.5
+  ```
+
+  The schema only validates the `<package>@<version>` shape;
+  consumers (e.g. `adl-cli`) are responsible for resolving each entry
+  against the sandbox's native package source — Nixpkgs for flox, an
+  apt/apk package or devcontainer feature for devcontainer, image
+  layers for dockerCompose. The field is optional and defaults to
+  empty.
 
 ## Consumers
 

--- a/schema/v1/schema.json
+++ b/schema/v1/schema.json
@@ -327,10 +327,18 @@
     },
     "DevelopmentConfig": {
       "type": "object",
-      "description": "Local development experience for the agent: sandboxed dev environments (flox, devcontainer, dockerCompose) and AI-assistant integration (CLAUDE.md/AGENTS.md generation, claude-code provisioning).",
+      "description": "Local development experience for the agent: sandboxed dev environments (flox, devcontainer, dockerCompose), AI-assistant integration (CLAUDE.md/AGENTS.md generation, claude-code provisioning), and extra sandbox-level dependencies (deps) for tools that don't belong to any single language's package manager (e.g. deno, kubectl, terraform).",
       "properties": {
         "sandbox": { "$ref": "#/definitions/SandboxConfig" },
-        "ai": { "$ref": "#/definitions/AIConfig" }
+        "ai": { "$ref": "#/definitions/AIConfig" },
+        "deps": {
+          "type": "array",
+          "description": "Extra packages to install into the development sandbox (flox, devcontainer, dockerCompose) on top of whatever the generator pulls in by default. Use this for cross-cutting tools that aren't tied to one of the project's languages — e.g. 'deno@2.1.4', 'kubectl@1.31.0', 'terraform@1.9.5'. Each entry follows the '<package>@<version>' form; consumers are responsible for resolving the package against the sandbox's native package source (Nixpkgs for flox, apt/apk/feature for devcontainer, image layers for dockerCompose).",
+          "items": {
+            "type": "string",
+            "pattern": "^\\S+@\\S+$"
+          }
+        }
       }
     },
     "SandboxConfig": {


### PR DESCRIPTION
## Summary

Adds an optional `spec.development.deps` array to the v1 schema, letting manifest authors declare extra packages the development sandbox (flox, devcontainer, dockerCompose) should pull in on top of generator defaults — useful for cross-cutting tools that don't belong to any single language's package manager (e.g. `deno` for ad-hoc scripting alongside a Go service, `kubectl`, `terraform`).

- New optional `deps` array under `DevelopmentConfig` in `schema/v1/schema.json`
- Each entry follows the `<package>@<version>` shape (same `^\S+@\S+$` regex as `VendorConfig.deps`)
- README updated with a bullet and a YAML example under *Development sandboxes*

The change is purely additive within `schema/v1/`, so it respects the strict-additive contract for v1.

Closes #15

Generated with [Claude Code](https://claude.ai/code)