### PR TITLE
feat(schema): Add optional author, license, and tags to Metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,14 @@ metadata:
   name: customer-support
   description: AI agent for handling customer inquiries
   version: "1.0.0"
+  author:
+    name: Acme Corp
+    email: agents@acme.example
+    url: https://acme.example
+  license: Apache-2.0
+  tags:
+    - support
+    - customer-service
 spec:
   capabilities:
     streaming: true
@@ -119,6 +127,31 @@ spec:
         enabled: false
       infer:
         enabled: false
+```
+
+### Agent metadata
+
+`metadata` is required and carries three mandatory fields — `name`, `description`, and `version` — plus three optional fields that travel with the manifest rather than being supplied by a downstream catalog or registry:
+
+- `metadata.author` — `{ name (required), email?, url? }`. Attribution and contact for whoever publishes the agent.
+- `metadata.license` — SPDX identifier (or `Proprietary`) the agent is distributed under. Uses the same accepted set as [`Skill.license`](#skill-licensing).
+- `metadata.tags` — `string[]`. Agent-level discoverability tags (e.g. `calendar`, `automation`). Consumers may merge these with tool- and skill-level tags when indexing.
+
+All three are optional and additive; manifests that omit them remain valid.
+
+```yaml
+metadata:
+  name: customer-support
+  description: AI agent for handling customer inquiries
+  version: "1.0.0"
+  author:
+    name: Acme Corp
+    email: agents@acme.example
+    url: https://acme.example
+  license: Apache-2.0
+  tags:
+    - support
+    - customer-service
 ```
 
 ### Skill licensing

--- a/schema/v1/schema.json
+++ b/schema/v1/schema.json
@@ -30,6 +30,43 @@
         "version": {
           "type": "string",
           "pattern": "^\\d+\\.\\d+\\.\\d+$"
+        },
+        "author": {
+          "type": "object",
+          "description": "Author of the agent. Optional; when provided, 'name' is required. 'email' and 'url' are optional contact fields.",
+          "required": ["name"],
+          "additionalProperties": false,
+          "properties": {
+            "name": { "type": "string" },
+            "email": { "type": "string", "format": "email" },
+            "url": { "type": "string", "format": "uri" }
+          }
+        },
+        "license": {
+          "type": "string",
+          "description": "SPDX identifier under which the agent is distributed, or \"Proprietary\" for closed-source agents. Mirrors the enum used for Skill.license so the same accepted set applies at the agent level. New identifiers may be added in future minor versions of the schema.",
+          "enum": [
+            "MIT",
+            "Apache-2.0",
+            "BSD-2-Clause",
+            "BSD-3-Clause",
+            "GPL-2.0",
+            "GPL-3.0",
+            "LGPL-2.1",
+            "LGPL-3.0",
+            "MPL-2.0",
+            "ISC",
+            "CC0-1.0",
+            "CC-BY-4.0",
+            "CC-BY-SA-4.0",
+            "Unlicense",
+            "Proprietary"
+          ]
+        },
+        "tags": {
+          "type": "array",
+          "description": "Discoverability tags for the agent (e.g. 'calendar', 'automation'). Consumers may merge these with tool- and skill-level tags when indexing.",
+          "items": { "type": "string" }
         }
       }
     },


### PR DESCRIPTION
## Summary

Extends the v1 `Metadata` definition with three optional, additive fields:

- `metadata.author` — `{ name (required), email?, url? }` for attribution and contact.
- `metadata.license` — SPDX identifier (or `Proprietary`), mirroring the enum used by `Skill.license`.
- `metadata.tags` — `string[]` for agent-level discoverability tags.

All three are optional; `Metadata.required` is unchanged, so existing manifests remain valid. README example and a new "Agent metadata" subsection updated to document the fields.

Closes #19

## Test plan

- [ ] `task compile` passes in CI.
- [ ] An existing real-world `agent.yaml` (e.g. `inference-gateway/google-calendar-agent/agent.yaml`) still validates unchanged.
- [ ] A manifest extended with `author`, `license`, and `tags` validates.

🤖 Generated with [Claude Code](https://claude.ai/code)