### PR TITLE
feat(docs): Add VitePress documentation site under docs/

### DIFF
--- a/.flox/env/manifest.lock
+++ b/.flox/env/manifest.lock
@@ -23,6 +23,10 @@
       "nodejs_24": {
         "pkg-path": "nodejs_24",
         "version": "24.15.0"
+      },
+      "prettier": {
+        "pkg-path": "prettier",
+        "version": "^3.8.3"
       }
     },
     "hook": {
@@ -490,6 +494,122 @@
       ],
       "outputs": {
         "out": "/nix/store/5a8ysg1jnj8jmzzyfcfw7rvpvnp5rfpa-nodejs-24.15.0"
+      },
+      "system": "x86_64-linux",
+      "group": "toplevel",
+      "priority": 5
+    },
+    {
+      "attr_path": "prettier",
+      "broken": false,
+      "derivation": "/nix/store/1gn4wfid50smxbcaghsfjg3wqh96ykgb-prettier-3.8.3.drv",
+      "description": "Code formatter",
+      "install_id": "prettier",
+      "license": "MIT",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=29916453413845e54a65b8a1cf996842300cd299",
+      "name": "prettier-3.8.3",
+      "pname": "prettier",
+      "rev": "29916453413845e54a65b8a1cf996842300cd299",
+      "rev_count": 1003640,
+      "rev_date": "2026-05-23T03:54:30Z",
+      "scrape_date": "2026-05-24T07:06:30.282371Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "3.8.3",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/p66lch2l5idjix079nw6dbcp81svzjws-prettier-3.8.3"
+      },
+      "system": "aarch64-darwin",
+      "group": "toplevel",
+      "priority": 5
+    },
+    {
+      "attr_path": "prettier",
+      "broken": false,
+      "derivation": "/nix/store/dly1idks1ayrsfxkcfylawmcnfla2d6p-prettier-3.8.3.drv",
+      "description": "Code formatter",
+      "install_id": "prettier",
+      "license": "MIT",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=29916453413845e54a65b8a1cf996842300cd299",
+      "name": "prettier-3.8.3",
+      "pname": "prettier",
+      "rev": "29916453413845e54a65b8a1cf996842300cd299",
+      "rev_count": 1003640,
+      "rev_date": "2026-05-23T03:54:30Z",
+      "scrape_date": "2026-05-24T07:35:04.369493Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "3.8.3",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/4k98mwg6q91nrdnfh9kxcw0ifns7rcla-prettier-3.8.3"
+      },
+      "system": "aarch64-linux",
+      "group": "toplevel",
+      "priority": 5
+    },
+    {
+      "attr_path": "prettier",
+      "broken": false,
+      "derivation": "/nix/store/lwykmlkzrszcvhpnmdd2g1f56m3269di-prettier-3.8.3.drv",
+      "description": "Code formatter",
+      "install_id": "prettier",
+      "license": "MIT",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=29916453413845e54a65b8a1cf996842300cd299",
+      "name": "prettier-3.8.3",
+      "pname": "prettier",
+      "rev": "29916453413845e54a65b8a1cf996842300cd299",
+      "rev_count": 1003640,
+      "rev_date": "2026-05-23T03:54:30Z",
+      "scrape_date": "2026-05-24T08:02:13.272576Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "3.8.3",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/15mp846gfvf4ca67kl9x63j4a8ddzs7j-prettier-3.8.3"
+      },
+      "system": "x86_64-darwin",
+      "group": "toplevel",
+      "priority": 5
+    },
+    {
+      "attr_path": "prettier",
+      "broken": false,
+      "derivation": "/nix/store/lpzq8872xnj626awa50r4ggspd4q3yzl-prettier-3.8.3.drv",
+      "description": "Code formatter",
+      "install_id": "prettier",
+      "license": "MIT",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=29916453413845e54a65b8a1cf996842300cd299",
+      "name": "prettier-3.8.3",
+      "pname": "prettier",
+      "rev": "29916453413845e54a65b8a1cf996842300cd299",
+      "rev_count": 1003640,
+      "rev_date": "2026-05-23T03:54:30Z",
+      "scrape_date": "2026-05-24T08:32:57.462671Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "3.8.3",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/phjkrasanj180ckfhkjb82az4am3v39z-prettier-3.8.3"
       },
       "system": "x86_64-linux",
       "group": "toplevel",

--- a/.flox/env/manifest.toml
+++ b/.flox/env/manifest.toml
@@ -12,6 +12,8 @@ claude-code.pkg-group = "ai"
 codex.pkg-path = "codex"
 codex.version = "^0.133.0"
 codex.pkg-group = "ai"
+prettier.pkg-path = "prettier"
+prettier.version = "^3.8.3"
 
 [hook]
 on-activate = """

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,7 @@
+schema/v1/schema.json
+CHANGELOG.md
+AGENTS.md
+CLAUDE.md
+README.md
+.infer
+.github

--- a/README.md
+++ b/README.md
@@ -8,12 +8,16 @@ A declarative language for defining AI agents, their capabilities, and skills. T
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg?style=flat-square)](LICENSE)
 [![Release](https://img.shields.io/github/v/release/inference-gateway/adl?style=flat-square&logo=github)](https://github.com/inference-gateway/adl/releases)
 [![Schema Version](https://img.shields.io/badge/schema-v1-blue.svg?style=flat-square)](./schema/v1/schema.json)
+[![Docs](https://img.shields.io/badge/docs-adl.inference--gateway.com-3c8772?style=flat-square&logo=readthedocs&logoColor=white)](https://adl.inference-gateway.com/v1/)
+
+📖 **Full documentation:** [adl.inference-gateway.com/v1](https://adl.inference-gateway.com/v1/)
 
 </div>
 
 ## Table of Contents
 
 - [What is ADL?](#what-is-adl)
+- [Documentation](#documentation)
 - [Layout](#layout)
 - [Example manifest](#example-manifest)
 - [Consumers](#consumers)
@@ -21,6 +25,16 @@ A declarative language for defining AI agents, their capabilities, and skills. T
 - [Why ADL?](#why-adl)
 - [Contributing](#contributing)
 - [License](#license)
+
+## Documentation
+
+Extensive, browsable documentation for ADL — concepts, a per-field
+schema reference, and copy-pasteable manifest examples — lives at
+[**adl.inference-gateway.com/v1**](https://adl.inference-gateway.com/v1/).
+The site source is a VitePress project under [`docs/`](./docs/).
+
+This README stays intentionally short: the docs site is the long-form
+companion, and it's the right place to link to from your own projects.
 
 ## What is ADL?
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -10,6 +10,11 @@ tasks:
     cmds:
       - task --list
 
+  format:
+    desc: Format the JSON Schema
+    cmds:
+      - prettier --write .
+
   compile:
     desc: Compile the JSON Schema (same check CI runs)
     cmds:

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+.vitepress/dist
+.vitepress/cache
+package-lock.json

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -1,0 +1,141 @@
+import { defineConfig } from 'vitepress'
+
+// VitePress configuration for the ADL documentation site.
+//
+// The site is published at https://adl.inference-gateway.com/v1/ via GitHub Pages.
+// The `/v1/` base mirrors the schema's major-version directory layout
+// (`schema/v1/`) so that a future v2 schema can ship its own docs under `/v2/`
+// without colliding with v1.
+export default defineConfig({
+  base: '/v1/',
+  lang: 'en-US',
+  title: 'ADL',
+  titleTemplate: ':title — Agent Definition Language',
+  description:
+    'Agent Definition Language (ADL): a vendor-neutral, declarative specification for AI agents. Think of ADL as "OpenAPI for AI Agents".',
+  cleanUrls: true,
+  lastUpdated: true,
+  sitemap: {
+    hostname: 'https://adl.inference-gateway.com/v1/'
+  },
+  head: [
+    ['meta', { name: 'theme-color', content: '#3c8772' }],
+    ['meta', { property: 'og:title', content: 'Agent Definition Language (ADL)' }],
+    [
+      'meta',
+      {
+        property: 'og:description',
+        content:
+          'A declarative, vendor-neutral specification for AI agents — OpenAPI for AI agents.'
+      }
+    ],
+    ['meta', { property: 'og:type', content: 'website' }],
+    ['meta', { property: 'og:url', content: 'https://adl.inference-gateway.com/v1/' }]
+  ],
+  themeConfig: {
+    nav: [
+      { text: 'Guide', link: '/guide/introduction', activeMatch: '/guide/' },
+      { text: 'Reference', link: '/reference/', activeMatch: '/reference/' },
+      { text: 'Examples', link: '/examples/', activeMatch: '/examples/' },
+      {
+        text: 'v1',
+        items: [
+          {
+            text: 'Schema (JSON)',
+            link: 'https://github.com/inference-gateway/adl/blob/main/schema/v1/schema.json'
+          },
+          {
+            text: 'Releases',
+            link: 'https://github.com/inference-gateway/adl/releases'
+          },
+          {
+            text: 'Changelog',
+            link: 'https://github.com/inference-gateway/adl/blob/main/CHANGELOG.md'
+          }
+        ]
+      }
+    ],
+    sidebar: {
+      '/guide/': [
+        {
+          text: 'Introduction',
+          items: [
+            { text: 'What is ADL?', link: '/guide/introduction' },
+            { text: 'Getting Started', link: '/guide/getting-started' },
+            { text: 'Tools vs Skills', link: '/guide/tools-vs-skills' },
+            { text: 'Versioning', link: '/guide/versioning' }
+          ]
+        }
+      ],
+      '/reference/': [
+        {
+          text: 'Top-level',
+          items: [
+            { text: 'Overview', link: '/reference/' },
+            { text: 'apiVersion / kind', link: '/reference/api-version-kind' },
+            { text: 'metadata', link: '/reference/metadata' },
+            { text: 'spec', link: '/reference/spec' }
+          ]
+        },
+        {
+          text: 'spec.*',
+          items: [
+            { text: 'capabilities', link: '/reference/capabilities' },
+            { text: 'card', link: '/reference/card' },
+            { text: 'agent', link: '/reference/agent' },
+            { text: 'config', link: '/reference/config' },
+            { text: 'services', link: '/reference/services' },
+            { text: 'acronyms', link: '/reference/acronyms' },
+            { text: 'tools', link: '/reference/tools' },
+            { text: 'skills', link: '/reference/skills' },
+            { text: 'server', link: '/reference/server' },
+            { text: 'language', link: '/reference/language' },
+            { text: 'artifacts', link: '/reference/artifacts' },
+            { text: 'hooks', link: '/reference/hooks' },
+            { text: 'scm', link: '/reference/scm' },
+            { text: 'development', link: '/reference/development' },
+            { text: 'deployment', link: '/reference/deployment' }
+          ]
+        },
+        {
+          text: 'Appendix',
+          items: [
+            { text: 'License identifiers', link: '/reference/license-identifiers' }
+          ]
+        }
+      ],
+      '/examples/': [
+        {
+          text: 'Examples',
+          items: [
+            { text: 'Overview', link: '/examples/' },
+            { text: 'Customer Support Agent', link: '/examples/customer-support' },
+            { text: 'Minimal Agent', link: '/examples/minimal' },
+            { text: 'Multi-language Agent', link: '/examples/multi-language' }
+          ]
+        }
+      ]
+    },
+    socialLinks: [
+      { icon: 'github', link: 'https://github.com/inference-gateway/adl' }
+    ],
+    editLink: {
+      pattern:
+        'https://github.com/inference-gateway/adl/edit/main/docs/:path',
+      text: 'Edit this page on GitHub'
+    },
+    footer: {
+      message:
+        'Released under the <a href="https://github.com/inference-gateway/adl/blob/main/LICENSE">Apache 2.0 License</a>.',
+      copyright:
+        'Copyright © 2025 — <a href="https://github.com/inference-gateway">Inference Gateway</a>'
+    },
+    search: {
+      provider: 'local'
+    },
+    outline: {
+      level: [2, 3],
+      label: 'On this page'
+    }
+  }
+})

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from 'vitepress'
+import { defineConfig } from "vitepress";
 
 // VitePress configuration for the ADL documentation site.
 //
@@ -7,135 +7,146 @@ import { defineConfig } from 'vitepress'
 // (`schema/v1/`) so that a future v2 schema can ship its own docs under `/v2/`
 // without colliding with v1.
 export default defineConfig({
-  base: '/v1/',
-  lang: 'en-US',
-  title: 'ADL',
-  titleTemplate: ':title — Agent Definition Language',
+  base: "/v1/",
+  lang: "en-US",
+  title: "ADL",
+  titleTemplate: ":title — Agent Definition Language",
   description:
     'Agent Definition Language (ADL): a vendor-neutral, declarative specification for AI agents. Think of ADL as "OpenAPI for AI Agents".',
   cleanUrls: true,
   lastUpdated: true,
   sitemap: {
-    hostname: 'https://adl.inference-gateway.com/v1/'
+    hostname: "https://adl.inference-gateway.com/v1/",
   },
   head: [
-    ['meta', { name: 'theme-color', content: '#3c8772' }],
-    ['meta', { property: 'og:title', content: 'Agent Definition Language (ADL)' }],
+    ["meta", { name: "theme-color", content: "#3c8772" }],
     [
-      'meta',
-      {
-        property: 'og:description',
-        content:
-          'A declarative, vendor-neutral specification for AI agents — OpenAPI for AI agents.'
-      }
+      "meta",
+      { property: "og:title", content: "Agent Definition Language (ADL)" },
     ],
-    ['meta', { property: 'og:type', content: 'website' }],
-    ['meta', { property: 'og:url', content: 'https://adl.inference-gateway.com/v1/' }]
+    [
+      "meta",
+      {
+        property: "og:description",
+        content:
+          "A declarative, vendor-neutral specification for AI agents — OpenAPI for AI agents.",
+      },
+    ],
+    ["meta", { property: "og:type", content: "website" }],
+    [
+      "meta",
+      { property: "og:url", content: "https://adl.inference-gateway.com/v1/" },
+    ],
   ],
   themeConfig: {
     nav: [
-      { text: 'Guide', link: '/guide/introduction', activeMatch: '/guide/' },
-      { text: 'Reference', link: '/reference/', activeMatch: '/reference/' },
-      { text: 'Examples', link: '/examples/', activeMatch: '/examples/' },
+      { text: "Guide", link: "/guide/introduction", activeMatch: "/guide/" },
+      { text: "Reference", link: "/reference/", activeMatch: "/reference/" },
+      { text: "Examples", link: "/examples/", activeMatch: "/examples/" },
       {
-        text: 'v1',
+        text: "v1",
         items: [
           {
-            text: 'Schema (JSON)',
-            link: 'https://github.com/inference-gateway/adl/blob/main/schema/v1/schema.json'
+            text: "Schema (JSON)",
+            link: "https://github.com/inference-gateway/adl/blob/main/schema/v1/schema.json",
           },
           {
-            text: 'Releases',
-            link: 'https://github.com/inference-gateway/adl/releases'
+            text: "Releases",
+            link: "https://github.com/inference-gateway/adl/releases",
           },
           {
-            text: 'Changelog',
-            link: 'https://github.com/inference-gateway/adl/blob/main/CHANGELOG.md'
-          }
-        ]
-      }
+            text: "Changelog",
+            link: "https://github.com/inference-gateway/adl/blob/main/CHANGELOG.md",
+          },
+        ],
+      },
     ],
     sidebar: {
-      '/guide/': [
+      "/guide/": [
         {
-          text: 'Introduction',
+          text: "Introduction",
           items: [
-            { text: 'What is ADL?', link: '/guide/introduction' },
-            { text: 'Getting Started', link: '/guide/getting-started' },
-            { text: 'Tools vs Skills', link: '/guide/tools-vs-skills' },
-            { text: 'Versioning', link: '/guide/versioning' }
-          ]
-        }
+            { text: "What is ADL?", link: "/guide/introduction" },
+            { text: "Getting Started", link: "/guide/getting-started" },
+            { text: "Tools vs Skills", link: "/guide/tools-vs-skills" },
+            { text: "Versioning", link: "/guide/versioning" },
+          ],
+        },
       ],
-      '/reference/': [
+      "/reference/": [
         {
-          text: 'Top-level',
+          text: "Top-level",
           items: [
-            { text: 'Overview', link: '/reference/' },
-            { text: 'apiVersion / kind', link: '/reference/api-version-kind' },
-            { text: 'metadata', link: '/reference/metadata' },
-            { text: 'spec', link: '/reference/spec' }
-          ]
+            { text: "Overview", link: "/reference/" },
+            { text: "apiVersion / kind", link: "/reference/api-version-kind" },
+            { text: "metadata", link: "/reference/metadata" },
+            { text: "spec", link: "/reference/spec" },
+          ],
         },
         {
-          text: 'spec.*',
+          text: "spec.*",
           items: [
-            { text: 'capabilities', link: '/reference/capabilities' },
-            { text: 'card', link: '/reference/card' },
-            { text: 'agent', link: '/reference/agent' },
-            { text: 'config', link: '/reference/config' },
-            { text: 'services', link: '/reference/services' },
-            { text: 'acronyms', link: '/reference/acronyms' },
-            { text: 'tools', link: '/reference/tools' },
-            { text: 'skills', link: '/reference/skills' },
-            { text: 'server', link: '/reference/server' },
-            { text: 'language', link: '/reference/language' },
-            { text: 'artifacts', link: '/reference/artifacts' },
-            { text: 'hooks', link: '/reference/hooks' },
-            { text: 'scm', link: '/reference/scm' },
-            { text: 'development', link: '/reference/development' },
-            { text: 'deployment', link: '/reference/deployment' }
-          ]
+            { text: "capabilities", link: "/reference/capabilities" },
+            { text: "card", link: "/reference/card" },
+            { text: "agent", link: "/reference/agent" },
+            { text: "config", link: "/reference/config" },
+            { text: "services", link: "/reference/services" },
+            { text: "acronyms", link: "/reference/acronyms" },
+            { text: "tools", link: "/reference/tools" },
+            { text: "skills", link: "/reference/skills" },
+            { text: "server", link: "/reference/server" },
+            { text: "language", link: "/reference/language" },
+            { text: "artifacts", link: "/reference/artifacts" },
+            { text: "hooks", link: "/reference/hooks" },
+            { text: "scm", link: "/reference/scm" },
+            { text: "development", link: "/reference/development" },
+            { text: "deployment", link: "/reference/deployment" },
+          ],
         },
         {
-          text: 'Appendix',
+          text: "Appendix",
           items: [
-            { text: 'License identifiers', link: '/reference/license-identifiers' }
-          ]
-        }
+            {
+              text: "License identifiers",
+              link: "/reference/license-identifiers",
+            },
+          ],
+        },
       ],
-      '/examples/': [
+      "/examples/": [
         {
-          text: 'Examples',
+          text: "Examples",
           items: [
-            { text: 'Overview', link: '/examples/' },
-            { text: 'Customer Support Agent', link: '/examples/customer-support' },
-            { text: 'Minimal Agent', link: '/examples/minimal' },
-            { text: 'Multi-language Agent', link: '/examples/multi-language' }
-          ]
-        }
-      ]
+            { text: "Overview", link: "/examples/" },
+            {
+              text: "Customer Support Agent",
+              link: "/examples/customer-support",
+            },
+            { text: "Minimal Agent", link: "/examples/minimal" },
+            { text: "Multi-language Agent", link: "/examples/multi-language" },
+          ],
+        },
+      ],
     },
     socialLinks: [
-      { icon: 'github', link: 'https://github.com/inference-gateway/adl' }
+      { icon: "github", link: "https://github.com/inference-gateway/adl" },
     ],
     editLink: {
-      pattern:
-        'https://github.com/inference-gateway/adl/edit/main/docs/:path',
-      text: 'Edit this page on GitHub'
+      pattern: "https://github.com/inference-gateway/adl/edit/main/docs/:path",
+      text: "Edit this page on GitHub",
     },
     footer: {
       message:
         'Released under the <a href="https://github.com/inference-gateway/adl/blob/main/LICENSE">Apache 2.0 License</a>.',
       copyright:
-        'Copyright © 2025 — <a href="https://github.com/inference-gateway">Inference Gateway</a>'
+        'Copyright © 2025 — <a href="https://github.com/inference-gateway">Inference Gateway</a>',
     },
     search: {
-      provider: 'local'
+      provider: "local",
     },
     outline: {
       level: [2, 3],
-      label: 'On this page'
-    }
-  }
-})
+      label: "On this page",
+    },
+  },
+});

--- a/docs/README.md
+++ b/docs/README.md
@@ -80,8 +80,11 @@ v2 site can live at `/v2/` without colliding with v1.
 
    on:
      push:
-       branches: [main]
-       paths: ['docs/**', '.github/workflows/deploy-docs.yml']
+       branches:
+         - main
+       paths:
+         - "docs/**"
+         - ".github/workflows/deploy-docs.yml"
      workflow_dispatch:
 
    permissions:
@@ -100,7 +103,7 @@ v2 site can live at `/v2/` without colliding with v1.
          - uses: actions/checkout@v6
          - uses: actions/setup-node@v6
            with:
-             node-version: '24.15.0'
+             node-version: "24.15.0"
          - run: npm ci
            working-directory: docs
          - run: npm run build

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,128 @@
+# ADL Documentation Site
+
+This directory contains the [VitePress](https://vitepress.dev/) source for
+the ADL documentation site, published at
+**https://adl.inference-gateway.com/v1/** via GitHub Pages.
+
+The site is the long-form companion to the canonical schema at
+[`schema/v1/schema.json`](../schema/v1/schema.json). The schema validates;
+the site explains.
+
+## Local development
+
+The docs site has its own `package.json` (it's a Vite project, not the
+schema-validation tooling). Node 20+ is recommended.
+
+```sh
+cd docs
+
+# Install dependencies
+npm install
+
+# Start the dev server (hot reload at http://localhost:5173)
+npm run dev
+
+# Build the static site into .vitepress/dist/
+npm run build
+
+# Preview the production build locally
+npm run preview
+```
+
+> The root of the repo intentionally has no `package.json` — see the root
+> [`CLAUDE.md`](../CLAUDE.md). The `docs/package.json` is scoped to this
+> Vite project and is separate from the ad-hoc `ajv` install used to
+> validate the schema itself.
+
+## Directory layout
+
+```
+docs/
+├── .vitepress/
+│   └── config.ts          # VitePress site config (nav, sidebar, base path)
+├── public/
+│   └── CNAME              # GitHub Pages custom domain (adl.inference-gateway.com)
+├── guide/                 # Conceptual guide pages
+├── reference/             # Per-field schema reference
+├── examples/              # Copy-pasteable ADL manifests
+├── index.md               # Landing page (Hero + features)
+├── package.json           # VitePress + Vue dev deps
+└── README.md              # This file
+```
+
+## Base path
+
+The site is configured with `base: '/v1/'` in
+[`.vitepress/config.ts`](./.vitepress/config.ts) so that the published
+URL is `https://adl.inference-gateway.com/v1/`. The `/v1/` prefix
+mirrors the schema's major-version directory (`schema/v1/`) so a future
+v2 site can live at `/v2/` without colliding with v1.
+
+## Deployment
+
+> **Setup required.** The GitHub Pages deployment workflow needs to be
+> created by a repo maintainer — the bot that opens this PR doesn't have
+> permission to modify files under `.github/workflows/`. A reference
+> workflow that builds the site and publishes it to GitHub Pages is
+> outlined below.
+
+1. In the repository settings, enable **GitHub Pages** with the
+   "GitHub Actions" build source.
+2. Add the custom domain `adl.inference-gateway.com` and configure the
+   DNS `CNAME` record at the registrar to point at GitHub Pages. The
+   `docs/public/CNAME` file in this directory ensures the domain is
+   preserved on each deploy.
+3. Add a workflow under `.github/workflows/deploy-docs.yml` along the
+   lines of:
+
+   ```yaml
+   name: Deploy docs
+
+   on:
+     push:
+       branches: [main]
+       paths: ['docs/**', '.github/workflows/deploy-docs.yml']
+     workflow_dispatch:
+
+   permissions:
+     contents: read
+     pages: write
+     id-token: write
+
+   concurrency:
+     group: pages
+     cancel-in-progress: false
+
+   jobs:
+     build:
+       runs-on: ubuntu-24.04
+       steps:
+         - uses: actions/checkout@v6
+         - uses: actions/setup-node@v6
+           with:
+             node-version: '24.15.0'
+         - run: npm ci
+           working-directory: docs
+         - run: npm run build
+           working-directory: docs
+         - uses: actions/configure-pages@v6
+         - uses: actions/upload-pages-artifact@v4
+           with:
+             path: docs/.vitepress/dist
+
+     deploy:
+       needs: build
+       runs-on: ubuntu-24.04
+       environment:
+         name: github-pages
+         url: ${{ steps.deployment.outputs.page_url }}
+       steps:
+         - id: deployment
+           uses: actions/deploy-pages@v5
+   ```
+
+## Contributing
+
+Open a PR. Follow the repo's
+[Conventional Commits](../CONTRIBUTING.md) convention — `docs:` for
+content-only changes, `feat(docs):` for new pages or sections.

--- a/docs/examples/customer-support.md
+++ b/docs/examples/customer-support.md
@@ -29,8 +29,11 @@ spec:
     protocolVersion: "1.0"
     url: https://agents.acme.example/customer-support
     preferredTransport: http+sse
-    defaultInputModes: [text/plain, application/json]
-    defaultOutputModes: [text/plain]
+    defaultInputModes:
+      - text/plain
+      - application/json
+    defaultOutputModes:
+      - text/plain
     documentationUrl: https://acme.example/docs/customer-support
     iconUrl: https://acme.example/agents/customer-support.png
 
@@ -56,33 +59,45 @@ spec:
       factory: NewZendeskTicketingClient
       description: Thin wrapper around the Zendesk API.
 
-  acronyms: [URL, HTTP, API, SLA, SLO]
+  acronyms:
+    - URL
+    - HTTP
+    - API
+    - SLA
+    - SLO
 
   tools:
     - id: knowledge_search
       name: knowledge_search
       description: Search the company knowledge base
-      tags: [knowledge, search]
+      tags:
+        - knowledge
+        - search
       schema:
         type: object
         properties:
           query: { type: string, description: The search query }
-        required: [query]
+        required:
+          - query
     - id: get_customer
       name: get_customer
       description: Look up a customer by ID
-      tags: [customer]
+      tags:
+        - customer
       schema:
         type: object
         properties:
           id: { type: string }
-        required: [id]
+        required:
+          - id
       inject:
         - customerRepo
     - id: escalate_ticket
       name: escalate_ticket
       description: Open a ticket in Zendesk for human follow-up
-      tags: [escalation, ticketing]
+      tags:
+        - escalation
+        - ticketing
       schema:
         type: object
         properties:
@@ -90,8 +105,15 @@ spec:
           summary: { type: string }
           priority:
             type: string
-            enum: [low, normal, high, urgent]
-        required: [customerId, summary, priority]
+            enum:
+              - low
+              - normal
+              - high
+              - urgent
+        required:
+          - customerId
+          - summary
+          - priority
       inject:
         - ticketingClient
 
@@ -101,13 +123,17 @@ spec:
       name: incident-response
       description: How to triage a paged production incident, draft an initial response, and notify stakeholders.
       license: Apache-2.0
-      tags: [operations, incident]
+      tags:
+        - operations
+        - incident
     - id: refund-policy
       bare: true
       name: refund-policy
       description: When and how to issue refunds, with required approvals.
       license: Proprietary
-      tags: [policy, refunds]
+      tags:
+        - policy
+        - refunds
 
   server:
     port: 8080

--- a/docs/examples/customer-support.md
+++ b/docs/examples/customer-support.md
@@ -1,0 +1,194 @@
+# Customer Support Agent
+
+A realistic manifest with most of the optional blocks turned on:
+provider/model selection, tools, skills, services, a flox sandbox with
+Claude Code provisioned, and CD targeting Cloud Run.
+
+```yaml
+apiVersion: adl.inference-gateway.com/v1
+kind: Agent
+metadata:
+  name: customer-support
+  description: AI agent for handling customer inquiries
+  version: "1.0.0"
+  author:
+    name: Acme Corp
+    email: agents@acme.example
+    url: https://acme.example
+  license: Apache-2.0
+  tags:
+    - support
+    - customer-service
+spec:
+  capabilities:
+    streaming: true
+    pushNotifications: true
+    stateTransitionHistory: true
+
+  card:
+    protocolVersion: "1.0"
+    url: https://agents.acme.example/customer-support
+    preferredTransport: http+sse
+    defaultInputModes: [text/plain, application/json]
+    defaultOutputModes: [text/plain]
+    documentationUrl: https://acme.example/docs/customer-support
+    iconUrl: https://acme.example/agents/customer-support.png
+
+  agent:
+    provider: deepseek
+    model: deepseek-v4-flash
+    systemPrompt: |
+      You are a professional customer support agent for Acme Corp.
+      Be concise, empathetic, and accurate. Escalate via the
+      `escalate_ticket` tool when you can't resolve an issue.
+    maxTokens: 4096
+    temperature: 0.3
+
+  services:
+    customerRepo:
+      type: repository
+      interface: CustomerRepository
+      factory: NewPostgresCustomerRepository
+      description: Customer lookup by ID, backed by Postgres.
+    ticketingClient:
+      type: client
+      interface: TicketingClient
+      factory: NewZendeskTicketingClient
+      description: Thin wrapper around the Zendesk API.
+
+  acronyms: [URL, HTTP, API, SLA, SLO]
+
+  tools:
+    - id: knowledge_search
+      name: knowledge_search
+      description: Search the company knowledge base
+      tags: [knowledge, search]
+      schema:
+        type: object
+        properties:
+          query: { type: string, description: The search query }
+        required: [query]
+    - id: get_customer
+      name: get_customer
+      description: Look up a customer by ID
+      tags: [customer]
+      schema:
+        type: object
+        properties:
+          id: { type: string }
+        required: [id]
+      inject:
+        - customerRepo
+    - id: escalate_ticket
+      name: escalate_ticket
+      description: Open a ticket in Zendesk for human follow-up
+      tags: [escalation, ticketing]
+      schema:
+        type: object
+        properties:
+          customerId: { type: string }
+          summary: { type: string }
+          priority:
+            type: string
+            enum: [low, normal, high, urgent]
+        required: [customerId, summary, priority]
+      inject:
+        - ticketingClient
+
+  skills:
+    - id: incident-response
+      bare: true
+      name: incident-response
+      description: How to triage a paged production incident, draft an initial response, and notify stakeholders.
+      license: Apache-2.0
+      tags: [operations, incident]
+    - id: refund-policy
+      bare: true
+      name: refund-policy
+      description: When and how to issue refunds, with required approvals.
+      license: Proprietary
+      tags: [policy, refunds]
+
+  server:
+    port: 8080
+    scheme: https
+    debug: false
+    auth:
+      enabled: true
+
+  language:
+    go:
+      module: github.com/acme/customer-support-agent
+      version: "1.26"
+      vendor:
+        deps:
+          - github.com/google/uuid@v1.6.0
+        devdeps:
+          - github.com/stretchr/testify@v1.9.0
+
+  artifacts:
+    enabled: true
+
+  hooks:
+    post:
+      - go vet ./...
+      - go test ./...
+
+  scm:
+    provider: github
+    url: https://github.com/acme/customer-support-agent
+    github_app: true
+    issue_templates: true
+    dependabot: true
+    ci: true
+    cd: true
+
+  development:
+    sandbox:
+      flox:
+        enabled: true
+      devcontainer:
+        enabled: false
+    ai:
+      claudecode:
+        enabled: true
+    deps:
+      - kubectl@1.31.0
+
+  deployment:
+    type: cloudrun
+    cloudrun:
+      image:
+        registry: us-central1-docker.pkg.dev
+        repository: acme/agents/customer-support
+        tag: v1.0.0
+        useCloudBuild: true
+      resources:
+        cpu: "1"
+        memory: 512Mi
+      scaling:
+        minInstances: 1
+        maxInstances: 10
+        concurrency: 80
+      service:
+        timeout: 300
+        allowUnauthenticated: false
+        serviceAccount: agents@acme.iam.gserviceaccount.com
+        executionEnvironment: gen2
+      environment:
+        LOG_LEVEL: info
+```
+
+## Highlights
+
+- **Three tools, three concerns.** `knowledge_search` is a stateless
+  retrieval call; `get_customer` and `escalate_ticket` use
+  [`inject`](/reference/tools#inject) to receive typed service handles
+  from `spec.services`.
+- **Two skills, two licences.** `incident-response` is open-source
+  (Apache-2.0); `refund-policy` is `Proprietary`. The licences ride
+  along in the generated `SKILL.md` frontmatter.
+- **Flox sandbox + Claude Code.** A developer can `flox activate` and
+  drop straight into a working dev shell with Claude Code provisioned.
+- **Cloud Run target.** CD ships the agent as a Cloud Run service with
+  pinned scaling and resource limits.

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -1,0 +1,11 @@
+# Examples
+
+Copy-pasteable ADL manifests for common shapes. Validate any of them
+with the same workflow described in
+[Getting Started](/guide/getting-started).
+
+| Example                                          | What it shows                                                          |
+|--------------------------------------------------|------------------------------------------------------------------------|
+| [Minimal Agent](./minimal)                       | The smallest valid manifest. Three required `spec` blocks, nothing else. |
+| [Customer Support Agent](./customer-support)     | A realistic agent with tools, skills, services, dev sandbox, and CD.   |
+| [Multi-language Agent](./multi-language)         | One manifest, three language outputs (Go + TypeScript + Rust).         |

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -4,8 +4,8 @@ Copy-pasteable ADL manifests for common shapes. Validate any of them
 with the same workflow described in
 [Getting Started](/guide/getting-started).
 
-| Example                                          | What it shows                                                          |
-|--------------------------------------------------|------------------------------------------------------------------------|
-| [Minimal Agent](./minimal)                       | The smallest valid manifest. Three required `spec` blocks, nothing else. |
-| [Customer Support Agent](./customer-support)     | A realistic agent with tools, skills, services, dev sandbox, and CD.   |
-| [Multi-language Agent](./multi-language)         | One manifest, three language outputs (Go + TypeScript + Rust).         |
+| Example                                      | What it shows                                                            |
+| -------------------------------------------- | ------------------------------------------------------------------------ |
+| [Minimal Agent](./minimal)                   | The smallest valid manifest. Three required `spec` blocks, nothing else. |
+| [Customer Support Agent](./customer-support) | A realistic agent with tools, skills, services, dev sandbox, and CD.     |
+| [Multi-language Agent](./multi-language)     | One manifest, three language outputs (Go + TypeScript + Rust).           |

--- a/docs/examples/minimal.md
+++ b/docs/examples/minimal.md
@@ -29,13 +29,13 @@ The schema demands four top-level fields — `apiVersion`, `kind`,
 `metadata`, `spec` — and three inside `spec`: `capabilities`, `server`,
 `language`. Every other block is opt-in.
 
-| Block                    | Why it's required                                                                                |
-|--------------------------|--------------------------------------------------------------------------------------------------|
-| `apiVersion` + `kind`    | Discriminators. They tell validators which schema to apply and reserve future kinds.             |
+| Block                                 | Why it's required                                                                          |
+| ------------------------------------- | ------------------------------------------------------------------------------------------ |
+| `apiVersion` + `kind`                 | Discriminators. They tell validators which schema to apply and reserve future kinds.       |
 | `metadata.{name,description,version}` | Identity. Without these, registries and generated projects have nothing to call the agent. |
-| `spec.capabilities`      | Protocol contract. Runtimes shouldn't have to guess about streaming, push, or history.            |
-| `spec.server`            | Where the agent listens. The generator can't emit a service without a port.                       |
-| `spec.language`          | What to generate. At least one target language is needed for the generator to do its job.         |
+| `spec.capabilities`                   | Protocol contract. Runtimes shouldn't have to guess about streaming, push, or history.     |
+| `spec.server`                         | Where the agent listens. The generator can't emit a service without a port.                |
+| `spec.language`                       | What to generate. At least one target language is needed for the generator to do its job.  |
 
 ## What you can add next
 

--- a/docs/examples/minimal.md
+++ b/docs/examples/minimal.md
@@ -1,0 +1,49 @@
+# Minimal Agent
+
+The smallest manifest that passes validation. Use this as a starting
+point and layer on optional blocks as needed.
+
+```yaml
+apiVersion: adl.inference-gateway.com/v1
+kind: Agent
+metadata:
+  name: hello-agent
+  description: Smallest valid ADL manifest
+  version: "0.1.0"
+spec:
+  capabilities:
+    streaming: true
+    pushNotifications: false
+    stateTransitionHistory: false
+  server:
+    port: 8080
+  language:
+    go:
+      module: github.com/example/hello-agent
+      version: "1.26"
+```
+
+## What's required (and why)
+
+The schema demands four top-level fields — `apiVersion`, `kind`,
+`metadata`, `spec` — and three inside `spec`: `capabilities`, `server`,
+`language`. Every other block is opt-in.
+
+| Block                    | Why it's required                                                                                |
+|--------------------------|--------------------------------------------------------------------------------------------------|
+| `apiVersion` + `kind`    | Discriminators. They tell validators which schema to apply and reserve future kinds.             |
+| `metadata.{name,description,version}` | Identity. Without these, registries and generated projects have nothing to call the agent. |
+| `spec.capabilities`      | Protocol contract. Runtimes shouldn't have to guess about streaming, push, or history.            |
+| `spec.server`            | Where the agent listens. The generator can't emit a service without a port.                       |
+| `spec.language`          | What to generate. At least one target language is needed for the generator to do its job.         |
+
+## What you can add next
+
+- An [`agent`](/reference/agent) block to pick a provider, model, and
+  system prompt.
+- [`tools`](/reference/tools) for function-call entrypoints.
+- [`skills`](/reference/skills) for markdown playbooks.
+- A [`development`](/reference/development) block to enable a flox or
+  devcontainer sandbox, and optionally a coding agent inside it.
+- A [`deployment`](/reference/deployment) block to target Kubernetes or
+  Cloud Run.

--- a/docs/examples/multi-language.md
+++ b/docs/examples/multi-language.md
@@ -27,14 +27,18 @@ spec:
     - id: log_entry
       name: log_entry
       description: Record a time entry against a project
-      tags: [time, tracking]
+      tags:
+        - time
+        - tracking
       schema:
         type: object
         properties:
           project: { type: string }
           hours: { type: number, minimum: 0 }
           notes: { type: string }
-        required: [project, hours]
+        required:
+          - project
+          - hours
 
   server:
     port: 8080
@@ -78,10 +82,10 @@ spec:
 For each entry under `spec.language`, the generator emits a complete
 project tree using that language's idioms:
 
-| Target       | Output                                                     |
-|--------------|------------------------------------------------------------|
-| `go`         | A Go module, `go.mod` with the listed `vendor` packages, idiomatic exported types and acronyms. |
-| `typescript` | An npm package with the listed dependencies in `package.json`, plus tsconfig and test setup. |
+| Target       | Output                                                                                                     |
+| ------------ | ---------------------------------------------------------------------------------------------------------- |
+| `go`         | A Go module, `go.mod` with the listed `vendor` packages, idiomatic exported types and acronyms.            |
+| `typescript` | An npm package with the listed dependencies in `package.json`, plus tsconfig and test setup.               |
 | `rust`       | A Cargo crate with the listed crates in `Cargo.toml`, the requested edition, and default features enabled. |
 
 `vendor.deps` and `vendor.devdeps` follow each language's native syntax —

--- a/docs/examples/multi-language.md
+++ b/docs/examples/multi-language.md
@@ -1,0 +1,96 @@
+# Multi-language Agent
+
+The same agent generated for three languages out of a single manifest.
+Useful when an agent ships both as a service (Go) and as SDK clients
+(TypeScript, Rust) consuming the same contract.
+
+```yaml
+apiVersion: adl.inference-gateway.com/v1
+kind: Agent
+metadata:
+  name: time-tracker
+  description: Lightweight time-tracking agent
+  version: "0.2.0"
+spec:
+  capabilities:
+    streaming: true
+    pushNotifications: false
+    stateTransitionHistory: false
+
+  agent:
+    provider: anthropic
+    model: claude-sonnet-4-7
+    systemPrompt: You help users log time against projects.
+    temperature: 0.2
+
+  tools:
+    - id: log_entry
+      name: log_entry
+      description: Record a time entry against a project
+      tags: [time, tracking]
+      schema:
+        type: object
+        properties:
+          project: { type: string }
+          hours: { type: number, minimum: 0 }
+          notes: { type: string }
+        required: [project, hours]
+
+  server:
+    port: 8080
+
+  language:
+    go:
+      module: github.com/example/time-tracker
+      version: "1.26"
+      vendor:
+        deps:
+          - github.com/google/uuid@v1.6.0
+        devdeps:
+          - github.com/stretchr/testify@v1.9.0
+
+    typescript:
+      packageName: "@example/time-tracker"
+      nodeVersion: "20"
+      vendor:
+        deps:
+          - zod@3.23.0
+        devdeps:
+          - vitest@1.6.0
+          - "@types/node@20.11.0"
+
+    rust:
+      packageName: time-tracker
+      version: "0.2.0"
+      edition: "2021"
+      features:
+        - server
+      vendor:
+        deps:
+          - tokio@1.36.0
+          - serde@1.0.200
+        devdeps:
+          - mockall@0.12.1
+```
+
+## What you get
+
+For each entry under `spec.language`, the generator emits a complete
+project tree using that language's idioms:
+
+| Target       | Output                                                     |
+|--------------|------------------------------------------------------------|
+| `go`         | A Go module, `go.mod` with the listed `vendor` packages, idiomatic exported types and acronyms. |
+| `typescript` | An npm package with the listed dependencies in `package.json`, plus tsconfig and test setup. |
+| `rust`       | A Cargo crate with the listed crates in `Cargo.toml`, the requested edition, and default features enabled. |
+
+`vendor.deps` and `vendor.devdeps` follow each language's native syntax —
+the schema only validates the `<package>@<version>` shape.
+
+## When this is overkill
+
+If you only need one language, configure only that one. The schema
+enforces `minProperties: 1` on `spec.language`, so omitting languages
+you don't need is the recommended default. Reach for the multi-language
+configuration when you have a real reason to keep multiple
+implementations in sync.

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -1,0 +1,92 @@
+# Getting Started
+
+This page walks through writing your first ADL manifest and validating it
+against the schema.
+
+## Prerequisites
+
+You need either:
+
+- **Node.js 24** (matches CI), or
+- **[flox](https://flox.dev/)** — `flox activate` in the schema repo runs
+  `npm install` of `ajv`, `ajv-cli`, and `ajv-formats` for you.
+
+## 1. Write a minimal manifest
+
+Create `agent.yaml`:
+
+```yaml
+apiVersion: adl.inference-gateway.com/v1
+kind: Agent
+metadata:
+  name: hello-agent
+  description: Smallest valid ADL manifest
+  version: "0.1.0"
+spec:
+  capabilities:
+    streaming: true
+    pushNotifications: false
+    stateTransitionHistory: false
+  server:
+    port: 8080
+  language:
+    go:
+      module: github.com/example/hello-agent
+      version: "1.26"
+```
+
+Every field above is required by the schema. We'll layer on the optional
+ones later.
+
+## 2. Validate it
+
+If you have [`go-task`](https://taskfile.dev) installed and you're inside
+the [schema repo](https://github.com/inference-gateway/adl):
+
+```sh
+task validate -- ./agent.yaml
+```
+
+Otherwise, run `ajv` directly:
+
+```sh
+npx ajv validate \
+  --spec=draft7 \
+  -c ajv-formats \
+  -s schema/v1/schema.json \
+  -d agent.yaml
+```
+
+A valid manifest prints `agent.yaml valid`. An invalid one prints the
+specific path, expected type, and offending value.
+
+## 3. Pin the schema version
+
+Once your manifest passes validation, decide which **tag** of the schema
+you want to pin against. Released schema tags are immutable — once `vX.Y.Z`
+is cut, the schema file at that tag never changes. Consumers (including
+`adl-cli`) pin to a specific tag in their `Taskfile.yml` or equivalent, so
+your manifests stay valid for the lifetime of the consumer's pin.
+
+```yaml
+# Example: pinning in a Taskfile
+vars:
+  ADL_SCHEMA_REF: v1.3.0
+  ADL_SCHEMA_URL: https://raw.githubusercontent.com/inference-gateway/adl/{{.ADL_SCHEMA_REF}}/schema/v1/schema.json
+```
+
+## 4. Generate a project (optional)
+
+If you want code, not just a manifest, feed your YAML to
+[`adl-cli`](https://github.com/inference-gateway/adl-cli) — the reference
+generator. It emits a complete agent project (server, handlers, tests,
+sandbox, CI, and deployment manifests) in the language you chose under
+`spec.language`.
+
+## What to read next
+
+- [Tools vs Skills](/guide/tools-vs-skills) — the most important concept
+  in ADL, and the one most people get wrong on first read.
+- [Reference: `metadata`](/reference/metadata) and
+  [Reference: `spec`](/reference/spec) — the two halves of the manifest.
+- [Examples](/examples/) — copy-pasteable manifests for common shapes.

--- a/docs/guide/introduction.md
+++ b/docs/guide/introduction.md
@@ -1,0 +1,91 @@
+# What is ADL?
+
+**ADL (Agent Definition Language)** is a vendor-neutral, declarative
+specification for AI agents. Just as [OpenAPI](https://www.openapis.org/)
+provides a standard way to describe REST services, ADL provides a standard
+way to describe agents: their metadata, capabilities, tools, skills, the AI
+provider behind them, the services they depend on, and the runtime they
+ship to.
+
+## The shape of a manifest
+
+Every ADL manifest is a YAML (or JSON) document with four required
+top-level fields:
+
+| Field        | Description                                                                                   |
+|--------------|-----------------------------------------------------------------------------------------------|
+| `apiVersion` | The schema version this manifest targets — currently `adl.inference-gateway.com/v1`.          |
+| `kind`       | Always `Agent`. Reserved so future kinds (e.g. `AgentTemplate`) can coexist.                  |
+| `metadata`   | Name, description, version, optional author, license, and tags.                               |
+| `spec`       | Everything that defines the agent's behaviour — capabilities, tools, skills, server, runtime. |
+
+```yaml
+apiVersion: adl.inference-gateway.com/v1
+kind: Agent
+metadata:
+  name: customer-support
+  description: AI agent for handling customer inquiries
+  version: "1.0.0"
+spec:
+  # ...
+```
+
+## What an ADL manifest is — and isn't
+
+ADL is **declarative**: it describes *what* an agent should look like, not
+*how* to build it. The schema deliberately stops at the boundary between
+declaration and implementation. Consumers — generators like
+[`adl-cli`](https://github.com/inference-gateway/adl-cli), runtimes, or
+registries — fill in the implementation, while ADL guarantees the shape of
+the contract.
+
+ADL **is**:
+
+- A single source of truth for an agent's surface and runtime.
+- A portable, version-pinned schema that downstream tools can rely on.
+- Strict about additive evolution: once a tag is cut, the schema at that
+  tag never changes.
+
+ADL is **not**:
+
+- A runtime. ADL itself doesn't execute anything; it's a description.
+- A model framework. ADL is provider-agnostic; it carries provider/model
+  identifiers but doesn't bundle SDKs.
+- A package manager. Vendor entries like `<package>@<version>` are
+  pass-through strings — the schema only validates the shape, the
+  consumer resolves them against the right ecosystem.
+
+## How it fits together
+
+```
+                            ┌────────────────────────┐
+                            │  agent.yaml (ADL v1)   │
+                            └───────────┬────────────┘
+                                        │
+                ┌───────────────────────┼───────────────────────┐
+                │                       │                       │
+        ┌───────▼──────┐        ┌───────▼──────┐        ┌───────▼──────┐
+        │   adl-cli    │        │   registry   │        │   runtime    │
+        │  (codegen)   │        │   indexing   │        │  (executor)  │
+        └───────┬──────┘        └──────────────┘        └──────────────┘
+                │
+   ┌────────────┼────────────┐
+   │            │            │
+┌──▼──┐      ┌──▼──┐      ┌──▼──┐
+│  Go │      │  TS │      │ Rust│
+└─────┘      └─────┘      └─────┘
+```
+
+Generators read the manifest, validate it against the schema, and emit a
+ready-to-run project. Registries can index by `metadata.tags` and the
+provider chosen in `spec.agent`. Runtimes can use the same manifest to
+load and execute the agent.
+
+## Next steps
+
+- [Getting Started](/guide/getting-started) — install the validator and
+  write your first manifest.
+- [Tools vs Skills](/guide/tools-vs-skills) — the single most important
+  concept in ADL.
+- [Schema Reference](/reference/) — every field, what it does, and how it
+  validates.

--- a/docs/guide/introduction.md
+++ b/docs/guide/introduction.md
@@ -13,7 +13,7 @@ Every ADL manifest is a YAML (or JSON) document with four required
 top-level fields:
 
 | Field        | Description                                                                                   |
-|--------------|-----------------------------------------------------------------------------------------------|
+| ------------ | --------------------------------------------------------------------------------------------- |
 | `apiVersion` | The schema version this manifest targets — currently `adl.inference-gateway.com/v1`.          |
 | `kind`       | Always `Agent`. Reserved so future kinds (e.g. `AgentTemplate`) can coexist.                  |
 | `metadata`   | Name, description, version, optional author, license, and tags.                               |
@@ -32,8 +32,8 @@ spec:
 
 ## What an ADL manifest is — and isn't
 
-ADL is **declarative**: it describes *what* an agent should look like, not
-*how* to build it. The schema deliberately stops at the boundary between
+ADL is **declarative**: it describes _what_ an agent should look like, not
+_how_ to build it. The schema deliberately stops at the boundary between
 declaration and implementation. Consumers — generators like
 [`adl-cli`](https://github.com/inference-gateway/adl-cli), runtimes, or
 registries — fill in the implementation, while ADL guarantees the shape of

--- a/docs/guide/tools-vs-skills.md
+++ b/docs/guide/tools-vs-skills.md
@@ -1,0 +1,122 @@
+# Tools vs Skills
+
+ADL distinguishes **two ways an agent can act**. The distinction is the
+single most important concept in the schema, and it shapes how downstream
+generators wire your manifest into runnable code.
+
+## The short version
+
+| | **Tool** | **Skill** |
+|---|---|---|
+| **Where it lives** | `spec.tools[]` | `spec.skills[]` |
+| **Shape** | Function call with a JSON Schema for inputs | Markdown playbook |
+| **How the agent uses it** | The model calls it as a function | The text is injected into the system prompt at startup |
+| **Generated as** | Code stubs in the target language | A bundled `SKILL.md` (or scaffolded blank with `bare: true`) |
+| **Best for** | Deterministic operations (DB query, API call, send email) | Workflows, policies, response patterns expressed in natural language |
+| **Carries a license?** | No | Yes (SPDX or `Proprietary`) |
+
+## Why two concepts?
+
+Real agents need both:
+
+- **Some things are deterministic.** "Look up this customer by ID" is a
+  function call against a database. You want a typed input, a typed
+  output, no creative interpretation by the LLM. That's a **tool**.
+- **Some things are judgment-laden.** "If the user reports an outage,
+  triage it like this: first check our status page, then …" is a
+  procedure written in prose. There's no `triageOutage()` function — you
+  want the model to follow the *approach*. That's a **skill**.
+
+Trying to express a skill as a tool produces a brittle, hard-to-test
+function with a giant `instructions: string` parameter. Trying to express
+a tool as a skill produces a model that hallucinates calls it can't
+actually make. The split keeps each in its lane.
+
+## Tools
+
+```yaml
+spec:
+  tools:
+    - id: knowledge_search
+      name: knowledge_search
+      description: Search the company knowledge base
+      tags:
+        - knowledge
+        - search
+      schema:
+        type: object
+        properties:
+          query:
+            type: string
+            description: The search query
+        required:
+          - query
+```
+
+The `schema` is free-form JSON Schema — it describes the tool's input
+arguments. The generator uses it to emit a typed function signature in
+your target language (e.g. a Go struct with json tags, a TypeScript
+interface, a Rust struct with serde derives) plus a stub function body
+for you to fill in.
+
+A tool's `id` must match `^[a-zA-Z_][a-zA-Z0-9_]*$` — it becomes a symbol
+name in generated code.
+
+Some `id`s are reserved as **built-in tools** that the generator
+implements for you (e.g. `read`, `bash`, `write`, `edit`). For those,
+`name`, `description`, `tags`, and `schema` may be omitted — the generator
+supplies them.
+
+See [Reference: tools](/reference/tools) for every field.
+
+## Skills
+
+```yaml
+spec:
+  skills:
+    - id: incident-response
+      bare: true
+      name: incident-response
+      description: How to triage a paged production incident, draft an initial
+        response, and notify stakeholders.
+      license: Apache-2.0
+      tags:
+        - operations
+        - incident
+```
+
+A skill is a markdown playbook. At agent startup, its contents are
+**injected into the system prompt** so the model sees the procedure as
+part of its instructions.
+
+Two sources:
+
+- **`bare: true`** — scaffold an empty `SKILL.md` for you to fill in
+  locally. Use this for proprietary workflows or one-off playbooks.
+- **From the registry** — set `source` (and optionally `version`) to pull
+  a published skill from the shared registry. Use this for common
+  playbooks you don't want to maintain yourself.
+
+Every skill carries a `license` (SPDX identifier or `Proprietary`), so
+the licence travels with the playbook regardless of where it's consumed.
+See [Reference: License identifiers](/reference/license-identifiers) for
+the accepted set.
+
+See [Reference: skills](/reference/skills) for every field.
+
+## Picking between them
+
+A quick decision tree:
+
+1. **Does the action have side effects on an external system?** (write to
+   DB, call an API, send a notification) → almost certainly a **tool**.
+2. **Is the "action" really a procedure the model should follow?** (how
+   to handle a refund request, how to escalate, what tone to use) →
+   **skill**.
+3. **Both?** Many features split cleanly: a `refund` *tool* that issues
+   the API call, plus a `refund-policy` *skill* that tells the model
+   *when* and *how* to issue refunds.
+
+When in doubt, ask: *if I removed the LLM and called this from a script,
+would the script still make sense?* If yes, it's a tool. If the
+"function" is "be a thoughtful assistant about X", it's a skill.

--- a/docs/guide/tools-vs-skills.md
+++ b/docs/guide/tools-vs-skills.md
@@ -6,14 +6,14 @@ generators wire your manifest into runnable code.
 
 ## The short version
 
-| | **Tool** | **Skill** |
-|---|---|---|
-| **Where it lives** | `spec.tools[]` | `spec.skills[]` |
-| **Shape** | Function call with a JSON Schema for inputs | Markdown playbook |
-| **How the agent uses it** | The model calls it as a function | The text is injected into the system prompt at startup |
-| **Generated as** | Code stubs in the target language | A bundled `SKILL.md` (or scaffolded blank with `bare: true`) |
-| **Best for** | Deterministic operations (DB query, API call, send email) | Workflows, policies, response patterns expressed in natural language |
-| **Carries a license?** | No | Yes (SPDX or `Proprietary`) |
+|                           | **Tool**                                                  | **Skill**                                                            |
+| ------------------------- | --------------------------------------------------------- | -------------------------------------------------------------------- |
+| **Where it lives**        | `spec.tools[]`                                            | `spec.skills[]`                                                      |
+| **Shape**                 | Function call with a JSON Schema for inputs               | Markdown playbook                                                    |
+| **How the agent uses it** | The model calls it as a function                          | The text is injected into the system prompt at startup               |
+| **Generated as**          | Code stubs in the target language                         | A bundled `SKILL.md` (or scaffolded blank with `bare: true`)         |
+| **Best for**              | Deterministic operations (DB query, API call, send email) | Workflows, policies, response patterns expressed in natural language |
+| **Carries a license?**    | No                                                        | Yes (SPDX or `Proprietary`)                                          |
 
 ## Why two concepts?
 
@@ -25,7 +25,7 @@ Real agents need both:
 - **Some things are judgment-laden.** "If the user reports an outage,
   triage it like this: first check our status page, then …" is a
   procedure written in prose. There's no `triageOutage()` function — you
-  want the model to follow the *approach*. That's a **skill**.
+  want the model to follow the _approach_. That's a **skill**.
 
 Trying to express a skill as a tool produces a brittle, hard-to-test
 function with a giant `instructions: string` parameter. Trying to express
@@ -113,10 +113,10 @@ A quick decision tree:
 2. **Is the "action" really a procedure the model should follow?** (how
    to handle a refund request, how to escalate, what tone to use) →
    **skill**.
-3. **Both?** Many features split cleanly: a `refund` *tool* that issues
-   the API call, plus a `refund-policy` *skill* that tells the model
-   *when* and *how* to issue refunds.
+3. **Both?** Many features split cleanly: a `refund` _tool_ that issues
+   the API call, plus a `refund-policy` _skill_ that tells the model
+   _when_ and _how_ to issue refunds.
 
-When in doubt, ask: *if I removed the LLM and called this from a script,
-would the script still make sense?* If yes, it's a tool. If the
+When in doubt, ask: _if I removed the LLM and called this from a script,
+would the script still make sense?_ If yes, it's a tool. If the
 "function" is "be a thoughtful assistant about X", it's a skill.

--- a/docs/guide/versioning.md
+++ b/docs/guide/versioning.md
@@ -8,14 +8,14 @@ shatter every pinned consumer.
 
 There are two versions to keep straight:
 
-| Version                              | What it identifies                          | Example                                  |
-|--------------------------------------|---------------------------------------------|------------------------------------------|
-| **`apiVersion`** (in the manifest)   | The major schema version this manifest uses | `adl.inference-gateway.com/v1`           |
-| **Git tag** of the schema repository | A specific snapshot of `schema/v1/schema.json` | `v1.3.0`                               |
+| Version                              | What it identifies                             | Example                        |
+| ------------------------------------ | ---------------------------------------------- | ------------------------------ |
+| **`apiVersion`** (in the manifest)   | The major schema version this manifest uses    | `adl.inference-gateway.com/v1` |
+| **Git tag** of the schema repository | A specific snapshot of `schema/v1/schema.json` | `v1.3.0`                       |
 
 The `apiVersion` and the directory under `schema/` always move together —
 `schema/v1/` matches `adl.inference-gateway.com/v1`. The git tag picks a
-*point in time* within that major version.
+_point in time_ within that major version.
 
 ## The additive contract
 
@@ -24,7 +24,7 @@ Inside a single major version (e.g. all of `v1`), only
 
 - ✅ New optional fields
 - ✅ New entries in `definitions`
-- ✅ New enum values *where consumers tolerate unknowns*
+- ✅ New enum values _where consumers tolerate unknowns_
 
 Forbidden until a new major version:
 
@@ -53,19 +53,19 @@ Releases are **manual**. A maintainer runs the `Release` workflow via
 
 The next version is decided by [Conventional Commits](https://www.conventionalcommits.org/):
 
-| Commit type | Effect            |
-|-------------|-------------------|
-| `feat`      | Minor bump        |
-| `fix`       | Patch bump        |
-| `impr`      | Patch bump        |
-| `refactor`  | Patch bump        |
-| `perf`      | Patch bump        |
-| `docs`      | Patch bump        |
-| `style`     | Patch bump        |
-| `test`      | Patch bump        |
-| `build`     | Patch bump        |
-| `ci`        | Patch bump        |
-| `chore`     | Patch bump        |
+| Commit type | Effect     |
+| ----------- | ---------- |
+| `feat`      | Minor bump |
+| `fix`       | Patch bump |
+| `impr`      | Patch bump |
+| `refactor`  | Patch bump |
+| `perf`      | Patch bump |
+| `docs`      | Patch bump |
+| `style`     | Patch bump |
+| `test`      | Patch bump |
+| `build`     | Patch bump |
+| `ci`        | Patch bump |
+| `chore`     | Patch bump |
 
 `chore(release):` is excluded from the changelog. PR titles become the
 squash-merge commit, so the **PR title must follow this convention**.

--- a/docs/guide/versioning.md
+++ b/docs/guide/versioning.md
@@ -1,0 +1,87 @@
+# Versioning
+
+ADL takes versioning seriously because downstream tools and runtimes pin
+to schema tags. A breaking change at the wrong moment would silently
+shatter every pinned consumer.
+
+## Two version numbers, two roles
+
+There are two versions to keep straight:
+
+| Version                              | What it identifies                          | Example                                  |
+|--------------------------------------|---------------------------------------------|------------------------------------------|
+| **`apiVersion`** (in the manifest)   | The major schema version this manifest uses | `adl.inference-gateway.com/v1`           |
+| **Git tag** of the schema repository | A specific snapshot of `schema/v1/schema.json` | `v1.3.0`                               |
+
+The `apiVersion` and the directory under `schema/` always move together —
+`schema/v1/` matches `adl.inference-gateway.com/v1`. The git tag picks a
+*point in time* within that major version.
+
+## The additive contract
+
+Inside a single major version (e.g. all of `v1`), only
+**backwards-compatible additions** are allowed:
+
+- ✅ New optional fields
+- ✅ New entries in `definitions`
+- ✅ New enum values *where consumers tolerate unknowns*
+
+Forbidden until a new major version:
+
+- ❌ Removing a field
+- ❌ Renaming a field
+- ❌ Tightening a constraint (e.g. narrowing a regex, adding a new
+  `required` entry)
+- ❌ Making an optional field required
+
+A breaking change requires a new directory (`schema/v2/`) and a new
+`apiVersion` string (`adl.inference-gateway.com/v2`). The two ship
+together, and `v1` is **not** removed when `v2` lands — both major
+versions coexist so existing manifests stay valid.
+
+## Released tags are immutable
+
+Once `vX.Y.Z` is cut, the schema file at that tag never changes. The git
+history may look editable, but consumers pin by tag and rely on that
+immutability. If a bug needs fixing, it ships as a **new patch tag** with
+a forward-compatible adjustment, not a rewrite of the old tag.
+
+## How tags get cut
+
+Releases are **manual**. A maintainer runs the `Release` workflow via
+`workflow_dispatch`; merging to `main` does not, by itself, cut a release.
+
+The next version is decided by [Conventional Commits](https://www.conventionalcommits.org/):
+
+| Commit type | Effect            |
+|-------------|-------------------|
+| `feat`      | Minor bump        |
+| `fix`       | Patch bump        |
+| `impr`      | Patch bump        |
+| `refactor`  | Patch bump        |
+| `perf`      | Patch bump        |
+| `docs`      | Patch bump        |
+| `style`     | Patch bump        |
+| `test`      | Patch bump        |
+| `build`     | Patch bump        |
+| `ci`        | Patch bump        |
+| `chore`     | Patch bump        |
+
+`chore(release):` is excluded from the changelog. PR titles become the
+squash-merge commit, so the **PR title must follow this convention**.
+
+`rc/*` branches publish to the `rc` channel from the same manual trigger.
+
+## Pinning, in practice
+
+Downstream tools should pin to a specific tag. For example, `adl-cli`
+pins via its `Taskfile.yml`:
+
+```yaml
+vars:
+  ADL_SCHEMA_REF: v1.3.0
+  ADL_SCHEMA_URL: https://raw.githubusercontent.com/inference-gateway/adl/{{.ADL_SCHEMA_REF}}/schema/v1/schema.json
+```
+
+Picking a tag is a deliberate decision: you adopt new fields by bumping
+the pin, not by chasing `main`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,83 @@
+---
+layout: home
+
+hero:
+  name: ADL
+  text: Agent Definition Language
+  tagline: A vendor-neutral, declarative specification for AI agents. Think "OpenAPI for AI agents".
+  actions:
+    - theme: brand
+      text: Get Started
+      link: /guide/getting-started
+    - theme: alt
+      text: Reference
+      link: /reference/
+    - theme: alt
+      text: View on GitHub
+      link: https://github.com/inference-gateway/adl
+
+features:
+  - icon: 📐
+    title: One manifest, many outputs
+    details: Describe an agent once in YAML. Generators turn it into Go, Rust, or TypeScript scaffolding, deployment manifests, and AI-assistant documentation.
+  - icon: 🧰
+    title: Tools and Skills
+    details: Function-call entrypoints (tools) and markdown playbooks (skills) live side-by-side, so deterministic operations and natural-language workflows are first-class citizens.
+  - icon: 🔌
+    title: Vendor-agnostic
+    details: Swap providers (OpenAI, Anthropic, DeepSeek, Google, Mistral, Ollama, Groq) without rewriting your agent. ADL stays portable across platforms.
+  - icon: 📦
+    title: Reproducible dev sandboxes
+    details: First-class flox, devcontainer, and docker-compose support. Provision Claude Code, Codex, Gemini, OpenCode, or Infer into the sandbox out of the box.
+  - icon: 🚀
+    title: Deployment built-in
+    details: Generate Kubernetes manifests or Cloud Run service configs from the same source of truth, with image, scaling, and resource constraints declaratively expressed.
+  - icon: 🔒
+    title: Strict additive contract
+    details: Inside a major version, only backwards-compatible additions are allowed. Tagged schema files are immutable. Consumers pin a tag and stay safe.
+---
+
+## Why ADL?
+
+The AI agent ecosystem is fragmenting fast. Every provider has a different
+surface; every framework has its own scaffolding. ADL gives teams **one
+declarative manifest** from which enterprise-ready agent code, configuration,
+documentation, and deployment manifests can be generated — vendor-agnostic
+and portable across platforms.
+
+```yaml
+apiVersion: adl.inference-gateway.com/v1
+kind: Agent
+metadata:
+  name: customer-support
+  description: AI agent for handling customer inquiries
+  version: "1.0.0"
+spec:
+  capabilities:
+    streaming: true
+    pushNotifications: true
+    stateTransitionHistory: true
+  agent:
+    provider: deepseek
+    model: deepseek-v4-flash
+    systemPrompt: You are a professional customer support agent.
+  server:
+    port: 8080
+  language:
+    go:
+      module: github.com/company/customer-support-agent
+      version: "1.26"
+```
+
+Feed that file into [`adl-cli`](https://github.com/inference-gateway/adl-cli) and
+get a complete agent project — server, handlers, tests, sandbox, CI, and
+deployment manifests — in the language of your choice.
+
+## Where to go next
+
+- **New to ADL?** Start with [What is ADL?](/guide/introduction) and then
+  [Getting Started](/guide/getting-started).
+- **Looking up a specific field?** Jump into the
+  [Schema Reference](/reference/).
+- **Want to see real manifests?** Browse the
+  [Examples](/examples/).

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "adl-docs",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Static documentation site for the Agent Definition Language (ADL).",
+  "type": "module",
+  "scripts": {
+    "dev": "vitepress dev",
+    "build": "vitepress build",
+    "preview": "vitepress preview"
+  },
+  "devDependencies": {
+    "vitepress": "^1.6.3",
+    "vue": "^3.5.13"
+  }
+}

--- a/docs/package.json
+++ b/docs/package.json
@@ -10,7 +10,7 @@
     "preview": "vitepress preview"
   },
   "devDependencies": {
-    "vitepress": "^1.6.3",
-    "vue": "^3.5.13"
+    "vitepress": "^1.6.4",
+    "vue": "^3.5.34"
   }
 }

--- a/docs/public/CNAME
+++ b/docs/public/CNAME
@@ -1,0 +1,1 @@
+adl.inference-gateway.com

--- a/docs/reference/acronyms.md
+++ b/docs/reference/acronyms.md
@@ -1,0 +1,38 @@
+# `spec.acronyms`
+
+A list of acronyms the generator should respect when producing identifiers.
+
+```yaml
+spec:
+  acronyms:
+    - URL
+    - HTTP
+    - SLA
+    - SLO
+    - API
+```
+
+## Shape
+
+- **Type:** `string[]`
+- **Required:** no
+
+## Why this exists
+
+When a generator turns a field like `httpUrl` into a Go identifier, the
+naïve translation is `HttpUrl`. That's wrong in idiomatic Go, which
+expects fully-uppercase acronyms (`HTTPURL`). Different languages have
+different conventions, but the underlying problem is the same: the
+generator needs to know which substrings are acronyms.
+
+Listing your project's acronyms once here lets the generator produce
+idiomatic identifiers consistently, instead of you fixing them up by
+hand in every emitted file.
+
+## Notes
+
+- Casing in this list is informational; the generator decides how to
+  apply each acronym based on the target language's conventions.
+- Add domain-specific acronyms as well as general ones — `SLA`, `JWT`,
+  `OIDC`, internal codes — anything that should not be camelCased into
+  something silly.

--- a/docs/reference/agent.md
+++ b/docs/reference/agent.md
@@ -1,0 +1,68 @@
+# `spec.agent`
+
+LLM-side configuration: which provider, which model, the system prompt,
+and standard sampling knobs.
+
+```yaml
+spec:
+  agent:
+    provider: deepseek
+    model: deepseek-v4-flash
+    systemPrompt: |
+      You are a professional customer support agent.
+    maxTokens: 4096
+    temperature: 0.3
+```
+
+## `provider`
+
+- **Type:** `string`
+- **Required:** no
+- **Allowed values:** `""`, `openai`, `anthropic`, `ollama`, `deepseek`,
+  `google`, `mistral`, `groq`.
+
+The provider behind the LLM. The empty string is allowed for manifests
+that defer provider selection to deploy time.
+
+New providers may be added in future **minor** schema versions. Consumers
+should be lenient about unknown values when reading newer manifests.
+
+## `model`
+
+- **Type:** `string`
+- **Required:** no
+
+The model identifier for the chosen provider (e.g. `gpt-4o-mini`,
+`claude-sonnet-4-7`, `deepseek-v4-flash`). The schema doesn't constrain
+the value — providers move fast, and the model catalogue is consumer
+territory.
+
+## `systemPrompt`
+
+- **Type:** `string`
+- **Required:** no
+
+The system prompt the agent boots with. Skills (see
+[`spec.skills`](./skills)) are injected on top of this prompt at
+startup, so keep `systemPrompt` focused on identity and ground rules,
+and put workflows into skills.
+
+## `maxTokens`
+
+- **Type:** `integer`
+- **Required:** no
+- **Minimum:** `1`
+
+Upper bound on tokens the model may emit per response. Optional — many
+runtimes default to a provider-specific value when omitted.
+
+## `temperature`
+
+- **Type:** `number`
+- **Required:** no
+- **Minimum:** `0`
+- **Maximum:** `2`
+
+Sampling temperature. `0` makes the model maximally deterministic, `2`
+maximally creative. The clamp matches what most providers actually
+accept.

--- a/docs/reference/api-version-kind.md
+++ b/docs/reference/api-version-kind.md
@@ -1,0 +1,50 @@
+# `apiVersion` / `kind`
+
+The two discriminator fields at the top of every manifest.
+
+## `apiVersion`
+
+- **Type:** `string`
+- **Required:** yes
+- **Allowed value:** `adl.inference-gateway.com/v1` (constant)
+
+```yaml
+apiVersion: adl.inference-gateway.com/v1
+```
+
+The `apiVersion` ties the manifest to a **major schema version**. The
+string and the directory under `schema/` always move in lockstep:
+`adl.inference-gateway.com/v1` matches `schema/v1/schema.json`. A future
+breaking version would be `adl.inference-gateway.com/v2`, served from
+`schema/v2/schema.json`.
+
+Why a constant in the schema? Because it guarantees a validator can't be
+tricked into accepting a v2-shaped manifest with a v1 declaration (or
+vice versa). Pick the right tag, pin to it, and the validator enforces
+the rest.
+
+## `kind`
+
+- **Type:** `string`
+- **Required:** yes
+- **Allowed value:** `Agent` (constant)
+
+```yaml
+kind: Agent
+```
+
+Reserved so future kinds — `AgentTemplate`, `AgentGroup`, etc. — can
+coexist in the same `apiVersion` family without breaking existing
+tooling.
+
+## Combined
+
+```yaml
+apiVersion: adl.inference-gateway.com/v1
+kind: Agent
+metadata: { ... }
+spec: { ... }
+```
+
+A manifest missing either field fails validation immediately, before any
+of the deeper structure is checked.

--- a/docs/reference/artifacts.md
+++ b/docs/reference/artifacts.md
@@ -13,8 +13,8 @@ spec:
 
 ## Fields
 
-| Field     | Type      | Required | Description                                                        |
-|-----------|-----------|:--------:|--------------------------------------------------------------------|
+| Field     | Type      | Required | Description                                                            |
+| --------- | --------- | :------: | ---------------------------------------------------------------------- |
 | `enabled` | `boolean` |    ✓     | When `true`, the generator emits CI/CD wiring that produces artifacts. |
 
 ## Why so minimal?

--- a/docs/reference/artifacts.md
+++ b/docs/reference/artifacts.md
@@ -1,0 +1,26 @@
+# `spec.artifacts`
+
+Toggles generation of build artifacts for the agent project (e.g.
+container images, archives) by the consumer's CD pipeline. The schema
+intentionally exposes only the on/off switch; downstream consumers
+decide what an "artifact" looks like.
+
+```yaml
+spec:
+  artifacts:
+    enabled: true
+```
+
+## Fields
+
+| Field     | Type      | Required | Description                                                        |
+|-----------|-----------|:--------:|--------------------------------------------------------------------|
+| `enabled` | `boolean` |    ✓     | When `true`, the generator emits CI/CD wiring that produces artifacts. |
+
+## Why so minimal?
+
+Artifact production is highly consumer-specific — image registries,
+release naming conventions, signing, attestation. Pinning that down in
+v1 of the schema would lock manifests to whatever was popular at the
+time. The single boolean keeps the contract durable while delegating
+the details.

--- a/docs/reference/capabilities.md
+++ b/docs/reference/capabilities.md
@@ -1,0 +1,47 @@
+# `spec.capabilities`
+
+Declares which protocol-level capabilities the agent supports. All three
+fields are required so the schema makes the agent's contract explicit —
+a runtime should never need to *guess* whether streaming is on.
+
+```yaml
+spec:
+  capabilities:
+    streaming: true
+    pushNotifications: true
+    stateTransitionHistory: true
+```
+
+## `streaming`
+
+- **Type:** `boolean`
+- **Required:** yes
+
+Whether the agent can stream incremental responses (typically
+token-by-token) back to the caller, instead of returning a single
+buffered result.
+
+## `pushNotifications`
+
+- **Type:** `boolean`
+- **Required:** yes
+
+Whether the agent can push notifications about state changes — useful
+for long-running tasks where the caller subscribes and is informed when
+something happens.
+
+## `stateTransitionHistory`
+
+- **Type:** `boolean`
+- **Required:** yes
+
+Whether the agent retains a record of state transitions over the course
+of a task. When `true`, callers can replay or audit how the agent
+reached its final state.
+
+## A note on defaults
+
+There are no defaults — every value must be explicitly `true` or
+`false`. This is intentional: a manifest that elides `streaming` would
+leave runtimes and clients unsure what to negotiate. Making the field
+required forces the author to think about it.

--- a/docs/reference/capabilities.md
+++ b/docs/reference/capabilities.md
@@ -2,7 +2,7 @@
 
 Declares which protocol-level capabilities the agent supports. All three
 fields are required so the schema makes the agent's contract explicit —
-a runtime should never need to *guess* whether streaming is on.
+a runtime should never need to _guess_ whether streaming is on.
 
 ```yaml
 spec:

--- a/docs/reference/card.md
+++ b/docs/reference/card.md
@@ -1,0 +1,35 @@
+# `spec.card`
+
+Optional protocol-card metadata. Surfaces information consumers need to
+*talk to* the deployed agent — protocol version, endpoint URL, supported
+input/output modes, and documentation links.
+
+```yaml
+spec:
+  card:
+    protocolVersion: "1.0"
+    url: https://agents.acme.example/customer-support
+    preferredTransport: http+sse
+    defaultInputModes:
+      - text/plain
+      - application/json
+    defaultOutputModes:
+      - text/plain
+    documentationUrl: https://acme.example/docs/customer-support
+    iconUrl: https://acme.example/agents/customer-support.png
+```
+
+## Fields
+
+| Field                | Type       | Description                                                |
+|----------------------|------------|------------------------------------------------------------|
+| `protocolVersion`    | `string`   | The agent-protocol version the deployed instance speaks.   |
+| `url`                | `string`   | Where the deployed agent lives.                            |
+| `preferredTransport` | `string`   | The transport the agent prefers (e.g. `http+sse`, `grpc`). |
+| `defaultInputModes`  | `string[]` | Media types the agent accepts by default.                  |
+| `defaultOutputModes` | `string[]` | Media types the agent returns by default.                  |
+| `documentationUrl`   | `string`   | Human-readable documentation for the agent.                |
+| `iconUrl`            | `string`   | Display icon for registries and UIs.                       |
+
+All fields are optional. If you don't surface a public card, omit the
+block entirely — it's purely declarative.

--- a/docs/reference/card.md
+++ b/docs/reference/card.md
@@ -1,7 +1,7 @@
 # `spec.card`
 
 Optional protocol-card metadata. Surfaces information consumers need to
-*talk to* the deployed agent — protocol version, endpoint URL, supported
+_talk to_ the deployed agent — protocol version, endpoint URL, supported
 input/output modes, and documentation links.
 
 ```yaml
@@ -22,7 +22,7 @@ spec:
 ## Fields
 
 | Field                | Type       | Description                                                |
-|----------------------|------------|------------------------------------------------------------|
+| -------------------- | ---------- | ---------------------------------------------------------- |
 | `protocolVersion`    | `string`   | The agent-protocol version the deployed instance speaks.   |
 | `url`                | `string`   | Where the deployed agent lives.                            |
 | `preferredTransport` | `string`   | The transport the agent prefers (e.g. `http+sse`, `grpc`). |

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -1,0 +1,40 @@
+# `spec.config`
+
+Free-form key/value configuration the agent should be given at runtime.
+The schema is deliberately permissive — it carries shape, not semantics.
+
+```yaml
+spec:
+  config:
+    cache:
+      ttlSeconds: 300
+      maxEntries: 1000
+    featureFlags:
+      newSearch: true
+      experimentalRanking: false
+```
+
+## Shape
+
+- **Type:** `object`
+- **Required:** no
+- **Structure:** every value at the top level must itself be an object;
+  inside that object, anything goes (any JSON value).
+
+```yaml
+spec:
+  config:
+    <group-name>:
+      <any-key>: <any-value>
+```
+
+So config is grouped one level deep — typically by subsystem — and the
+contents of each group are unconstrained.
+
+## Why so loose?
+
+`config` is the schema's escape hatch for project-specific configuration
+that doesn't fit a typed slot elsewhere. Generators pass the contents
+straight through to the agent's runtime config layer. If a particular
+key becomes common across agents, it's a candidate to graduate into a
+proper typed field in a future minor schema version.

--- a/docs/reference/deployment.md
+++ b/docs/reference/deployment.md
@@ -1,0 +1,117 @@
+# `spec.deployment`
+
+Where and how the agent ships in production. Pick a target with `type`,
+then configure the matching sub-block.
+
+```yaml
+spec:
+  deployment:
+    type: kubernetes
+    kubernetes:
+      image:
+        registry: ghcr.io
+        repository: company/customer-support-agent
+        tag: v1.0.0
+```
+
+## Fields
+
+| Field        | Type     | Required | Description                                                  |
+|--------------|----------|:--------:|--------------------------------------------------------------|
+| `type`       | `string` |          | enum: `kubernetes`, `cloudrun`. Selects the deployment target. |
+| `kubernetes` | `object` |          | See [Kubernetes](#kubernetes).                               |
+| `cloudrun`   | `object` |          | See [Cloud Run](#cloud-run).                                 |
+
+## Kubernetes {#kubernetes}
+
+```yaml
+spec:
+  deployment:
+    type: kubernetes
+    kubernetes:
+      image:
+        registry: ghcr.io
+        repository: company/customer-support-agent
+        tag: v1.0.0
+```
+
+| Field   | Description                                                  |
+|---------|--------------------------------------------------------------|
+| `image` | See [Image](#image).                                         |
+
+The Kubernetes block is intentionally minimal in v1 — it carries the
+**image** and leaves the rest (Deployment, Service, ConfigMap, …) to
+the generator's templating. Future minor versions may add typed slots
+for replica counts and resource limits as common patterns harden.
+
+## Cloud Run {#cloud-run}
+
+```yaml
+spec:
+  deployment:
+    type: cloudrun
+    cloudrun:
+      image:
+        registry: us-central1-docker.pkg.dev
+        repository: my-project/agents/customer-support
+        tag: v1.0.0
+        useCloudBuild: true
+      resources:
+        cpu: "1"
+        memory: 512Mi
+      scaling:
+        minInstances: 1
+        maxInstances: 10
+        concurrency: 80
+      service:
+        timeout: 300
+        allowUnauthenticated: false
+        serviceAccount: agents@my-project.iam.gserviceaccount.com
+        executionEnvironment: gen2
+      environment:
+        LOG_LEVEL: info
+        CACHE_TTL: "300"
+```
+
+| Field         | Reference                                |
+|---------------|------------------------------------------|
+| `image`       | [Image](#image)                          |
+| `resources`   | [Resources](#cloud-run-resources)        |
+| `scaling`     | [Scaling](#cloud-run-scaling)            |
+| `service`     | [Service](#cloud-run-service)            |
+| `environment` | `{ [key: string]: string }` — env vars.  |
+
+### Resources {#cloud-run-resources}
+
+| Field    | Type     | Description                                |
+|----------|----------|--------------------------------------------|
+| `cpu`    | `string` | CPU allocation per instance (e.g. `"1"`).  |
+| `memory` | `string` | Memory per instance (e.g. `512Mi`, `2Gi`). |
+
+### Scaling {#cloud-run-scaling}
+
+| Field          | Type      | Description                                   |
+|----------------|-----------|-----------------------------------------------|
+| `minInstances` | `integer` | Minimum number of instances kept warm.        |
+| `maxInstances` | `integer` | Cap on instances Cloud Run may spin up.       |
+| `concurrency`  | `integer` | Concurrent requests served per instance.      |
+
+### Service {#cloud-run-service}
+
+| Field                  | Type      | Description                                                       |
+|------------------------|-----------|-------------------------------------------------------------------|
+| `timeout`              | `integer` | Per-request timeout in seconds.                                   |
+| `allowUnauthenticated` | `boolean` | If `true`, the service is publicly invokable.                     |
+| `serviceAccount`       | `string`  | GCP service-account email the service runs as.                    |
+| `executionEnvironment` | `string`  | Cloud Run execution environment (e.g. `gen1`, `gen2`).            |
+
+## Image {#image}
+
+Used by both the `kubernetes` and `cloudrun` sub-blocks.
+
+| Field           | Type      | Description                                                  |
+|-----------------|-----------|--------------------------------------------------------------|
+| `registry`      | `string`  | Image registry (e.g. `ghcr.io`).                             |
+| `repository`    | `string`  | Image repository within the registry.                        |
+| `tag`           | `string`  | Image tag.                                                   |
+| `useCloudBuild` | `boolean` | If `true`, the generator wires in Google Cloud Build for image production. Most useful with `type: cloudrun`. |

--- a/docs/reference/deployment.md
+++ b/docs/reference/deployment.md
@@ -16,11 +16,11 @@ spec:
 
 ## Fields
 
-| Field        | Type     | Required | Description                                                  |
-|--------------|----------|:--------:|--------------------------------------------------------------|
+| Field        | Type     | Required | Description                                                    |
+| ------------ | -------- | :------: | -------------------------------------------------------------- |
 | `type`       | `string` |          | enum: `kubernetes`, `cloudrun`. Selects the deployment target. |
-| `kubernetes` | `object` |          | See [Kubernetes](#kubernetes).                               |
-| `cloudrun`   | `object` |          | See [Cloud Run](#cloud-run).                                 |
+| `kubernetes` | `object` |          | See [Kubernetes](#kubernetes).                                 |
+| `cloudrun`   | `object` |          | See [Cloud Run](#cloud-run).                                   |
 
 ## Kubernetes {#kubernetes}
 
@@ -35,9 +35,9 @@ spec:
         tag: v1.0.0
 ```
 
-| Field   | Description                                                  |
-|---------|--------------------------------------------------------------|
-| `image` | See [Image](#image).                                         |
+| Field   | Description          |
+| ------- | -------------------- |
+| `image` | See [Image](#image). |
 
 The Kubernetes block is intentionally minimal in v1 — it carries the
 **image** and leaves the rest (Deployment, Service, ConfigMap, …) to
@@ -73,45 +73,45 @@ spec:
         CACHE_TTL: "300"
 ```
 
-| Field         | Reference                                |
-|---------------|------------------------------------------|
-| `image`       | [Image](#image)                          |
-| `resources`   | [Resources](#cloud-run-resources)        |
-| `scaling`     | [Scaling](#cloud-run-scaling)            |
-| `service`     | [Service](#cloud-run-service)            |
-| `environment` | `{ [key: string]: string }` — env vars.  |
+| Field         | Reference                               |
+| ------------- | --------------------------------------- |
+| `image`       | [Image](#image)                         |
+| `resources`   | [Resources](#cloud-run-resources)       |
+| `scaling`     | [Scaling](#cloud-run-scaling)           |
+| `service`     | [Service](#cloud-run-service)           |
+| `environment` | `{ [key: string]: string }` — env vars. |
 
 ### Resources {#cloud-run-resources}
 
 | Field    | Type     | Description                                |
-|----------|----------|--------------------------------------------|
+| -------- | -------- | ------------------------------------------ |
 | `cpu`    | `string` | CPU allocation per instance (e.g. `"1"`).  |
 | `memory` | `string` | Memory per instance (e.g. `512Mi`, `2Gi`). |
 
 ### Scaling {#cloud-run-scaling}
 
-| Field          | Type      | Description                                   |
-|----------------|-----------|-----------------------------------------------|
-| `minInstances` | `integer` | Minimum number of instances kept warm.        |
-| `maxInstances` | `integer` | Cap on instances Cloud Run may spin up.       |
-| `concurrency`  | `integer` | Concurrent requests served per instance.      |
+| Field          | Type      | Description                              |
+| -------------- | --------- | ---------------------------------------- |
+| `minInstances` | `integer` | Minimum number of instances kept warm.   |
+| `maxInstances` | `integer` | Cap on instances Cloud Run may spin up.  |
+| `concurrency`  | `integer` | Concurrent requests served per instance. |
 
 ### Service {#cloud-run-service}
 
-| Field                  | Type      | Description                                                       |
-|------------------------|-----------|-------------------------------------------------------------------|
-| `timeout`              | `integer` | Per-request timeout in seconds.                                   |
-| `allowUnauthenticated` | `boolean` | If `true`, the service is publicly invokable.                     |
-| `serviceAccount`       | `string`  | GCP service-account email the service runs as.                    |
-| `executionEnvironment` | `string`  | Cloud Run execution environment (e.g. `gen1`, `gen2`).            |
+| Field                  | Type      | Description                                            |
+| ---------------------- | --------- | ------------------------------------------------------ |
+| `timeout`              | `integer` | Per-request timeout in seconds.                        |
+| `allowUnauthenticated` | `boolean` | If `true`, the service is publicly invokable.          |
+| `serviceAccount`       | `string`  | GCP service-account email the service runs as.         |
+| `executionEnvironment` | `string`  | Cloud Run execution environment (e.g. `gen1`, `gen2`). |
 
 ## Image {#image}
 
 Used by both the `kubernetes` and `cloudrun` sub-blocks.
 
-| Field           | Type      | Description                                                  |
-|-----------------|-----------|--------------------------------------------------------------|
-| `registry`      | `string`  | Image registry (e.g. `ghcr.io`).                             |
-| `repository`    | `string`  | Image repository within the registry.                        |
-| `tag`           | `string`  | Image tag.                                                   |
+| Field           | Type      | Description                                                                                                   |
+| --------------- | --------- | ------------------------------------------------------------------------------------------------------------- |
+| `registry`      | `string`  | Image registry (e.g. `ghcr.io`).                                                                              |
+| `repository`    | `string`  | Image repository within the registry.                                                                         |
+| `tag`           | `string`  | Image tag.                                                                                                    |
 | `useCloudBuild` | `boolean` | If `true`, the generator wires in Google Cloud Build for image production. Most useful with `type: cloudrun`. |

--- a/docs/reference/development.md
+++ b/docs/reference/development.md
@@ -33,11 +33,11 @@ spec:
 
 ## Fields
 
-| Field      | Reference                       | Description                                                                  |
-|------------|---------------------------------|------------------------------------------------------------------------------|
-| `sandbox`  | [sandbox](#sandbox)             | Reproducible dev environments (flox, devcontainer, dockerCompose).           |
-| `ai`       | [ai](#ai)                       | AI coding-agent provisioning (Claude Code, Codex, Gemini, OpenCode, Infer).  |
-| `deps`     | [deps](#deps)                   | Sandbox-level extra packages (cross-cutting, language-agnostic).             |
+| Field     | Reference           | Description                                                                 |
+| --------- | ------------------- | --------------------------------------------------------------------------- |
+| `sandbox` | [sandbox](#sandbox) | Reproducible dev environments (flox, devcontainer, dockerCompose).          |
+| `ai`      | [ai](#ai)           | AI coding-agent provisioning (Claude Code, Codex, Gemini, OpenCode, Infer). |
+| `deps`    | [deps](#deps)       | Sandbox-level extra packages (cross-cutting, language-agnostic).            |
 
 ## `sandbox` {#sandbox}
 
@@ -57,11 +57,11 @@ spec:
         enabled: false
 ```
 
-| Sandbox          | When to use                                                                  |
-|------------------|------------------------------------------------------------------------------|
-| `flox`           | Reproducible per-project dev shells via Nixpkgs, no container layer needed.  |
-| `devcontainer`   | VS Code (and compatible) Dev Containers — boots the project in a container.  |
-| `dockerCompose`  | Existing multi-service Docker Compose stack you want the agent to live in.   |
+| Sandbox         | When to use                                                                 |
+| --------------- | --------------------------------------------------------------------------- |
+| `flox`          | Reproducible per-project dev shells via Nixpkgs, no container layer needed. |
+| `devcontainer`  | VS Code (and compatible) Dev Containers — boots the project in a container. |
+| `dockerCompose` | Existing multi-service Docker Compose stack you want the agent to live in.  |
 
 Each sub-block has the shape `{ enabled: boolean }`. Enabling more than
 one is allowed if your project wants to ship multiple ways to enter the
@@ -90,13 +90,13 @@ spec:
         enabled: false
 ```
 
-| Field                | Coding agent                          |
-|----------------------|---------------------------------------|
-| `claudecode.enabled` | Anthropic **Claude Code**             |
-| `codex.enabled`      | OpenAI **Codex**                      |
-| `gemini.enabled`     | Google **Gemini**                     |
-| `opencode.enabled`   | **OpenCode**                          |
-| `infer.enabled`      | Inference Gateway **`infer`**         |
+| Field                | Coding agent                  |
+| -------------------- | ----------------------------- |
+| `claudecode.enabled` | Anthropic **Claude Code**     |
+| `codex.enabled`      | OpenAI **Codex**              |
+| `gemini.enabled`     | Google **Gemini**             |
+| `opencode.enabled`   | **OpenCode**                  |
+| `infer.enabled`      | Inference Gateway **`infer`** |
 
 Each sub-block has the shape `{ enabled: boolean }`. Multiple agents
 can be enabled at once if a project wants to ship configuration for
@@ -125,16 +125,16 @@ spec:
       - terraform@1.9.5
 ```
 
-| Aspect    | Detail                                                                                |
-|-----------|---------------------------------------------------------------------------------------|
-| **Shape** | `string[]`, each entry matching `^\S+@\S+$` (i.e. `<package>@<version>`).             |
-| **Default** | Empty.                                                                              |
+| Aspect         | Detail                                                                                                                    |
+| -------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| **Shape**      | `string[]`, each entry matching `^\S+@\S+$` (i.e. `<package>@<version>`).                                                 |
+| **Default**    | Empty.                                                                                                                    |
 | **Resolution** | Consumer responsibility: Nixpkgs for flox, apt/apk/devcontainer feature for devcontainer, image layers for dockerCompose. |
 
 The schema only validates the `<package>@<version>` shape. Consumers
 (e.g. `adl-cli`) are responsible for resolving each entry against the
 sandbox's native package source.
 
-> If you need a package that *is* tied to a specific language, use that
+> If you need a package that _is_ tied to a specific language, use that
 > language's [`vendor.deps` / `vendor.devdeps`](./language#vendor-config)
 > instead.

--- a/docs/reference/development.md
+++ b/docs/reference/development.md
@@ -1,0 +1,140 @@
+# `spec.development`
+
+Everything about the **local developer experience** for the agent
+project: reproducible sandboxes, AI coding-agent integration, and extra
+sandbox-level dependencies.
+
+```yaml
+spec:
+  development:
+    sandbox:
+      flox:
+        enabled: true
+      devcontainer:
+        enabled: false
+      dockerCompose:
+        enabled: false
+    ai:
+      claudecode:
+        enabled: true
+      codex:
+        enabled: false
+      gemini:
+        enabled: false
+      opencode:
+        enabled: false
+      infer:
+        enabled: false
+    deps:
+      - deno@2.1.4
+      - kubectl@1.31.0
+      - terraform@1.9.5
+```
+
+## Fields
+
+| Field      | Reference                       | Description                                                                  |
+|------------|---------------------------------|------------------------------------------------------------------------------|
+| `sandbox`  | [sandbox](#sandbox)             | Reproducible dev environments (flox, devcontainer, dockerCompose).           |
+| `ai`       | [ai](#ai)                       | AI coding-agent provisioning (Claude Code, Codex, Gemini, OpenCode, Infer).  |
+| `deps`     | [deps](#deps)                   | Sandbox-level extra packages (cross-cutting, language-agnostic).             |
+
+## `sandbox` {#sandbox}
+
+Selects reproducible dev environments. `flox`, `devcontainer`, and
+`dockerCompose` are alternative ways to package the same sandbox; pick
+what suits the team. Each is independently toggleable.
+
+```yaml
+spec:
+  development:
+    sandbox:
+      flox:
+        enabled: true
+      devcontainer:
+        enabled: false
+      dockerCompose:
+        enabled: false
+```
+
+| Sandbox          | When to use                                                                  |
+|------------------|------------------------------------------------------------------------------|
+| `flox`           | Reproducible per-project dev shells via Nixpkgs, no container layer needed.  |
+| `devcontainer`   | VS Code (and compatible) Dev Containers — boots the project in a container.  |
+| `dockerCompose`  | Existing multi-service Docker Compose stack you want the agent to live in.   |
+
+Each sub-block has the shape `{ enabled: boolean }`. Enabling more than
+one is allowed if your project wants to ship multiple ways to enter the
+sandbox.
+
+## `ai` {#ai}
+
+Configures generation of AI-assistant documentation (`CLAUDE.md`,
+`AGENTS.md`) and provisioning of coding agents inside the sandbox. Each
+supported coding agent is toggled independently, and every agent is
+**disabled by default**.
+
+```yaml
+spec:
+  development:
+    ai:
+      claudecode:
+        enabled: true
+      codex:
+        enabled: false
+      gemini:
+        enabled: false
+      opencode:
+        enabled: false
+      infer:
+        enabled: false
+```
+
+| Field                | Coding agent                          |
+|----------------------|---------------------------------------|
+| `claudecode.enabled` | Anthropic **Claude Code**             |
+| `codex.enabled`      | OpenAI **Codex**                      |
+| `gemini.enabled`     | Google **Gemini**                     |
+| `opencode.enabled`   | **OpenCode**                          |
+| `infer.enabled`      | Inference Gateway **`infer`**         |
+
+Each sub-block has the shape `{ enabled: boolean }`. Multiple agents
+can be enabled at once if a project wants to ship configuration for
+more than one.
+
+## `deps` {#deps}
+
+Extra packages to install into the **development sandbox itself** (flox,
+devcontainer, dockerCompose) on top of whatever the generator pulls in
+by default.
+
+Use this for cross-cutting tools that **aren't tied to a single
+language** — e.g. a Go service that also needs `deno` for quick
+scripting, or a TypeScript agent that wants `kubectl` available in the
+dev shell.
+
+```yaml
+spec:
+  development:
+    sandbox:
+      flox:
+        enabled: true
+    deps:
+      - deno@2.1.4
+      - kubectl@1.31.0
+      - terraform@1.9.5
+```
+
+| Aspect    | Detail                                                                                |
+|-----------|---------------------------------------------------------------------------------------|
+| **Shape** | `string[]`, each entry matching `^\S+@\S+$` (i.e. `<package>@<version>`).             |
+| **Default** | Empty.                                                                              |
+| **Resolution** | Consumer responsibility: Nixpkgs for flox, apt/apk/devcontainer feature for devcontainer, image layers for dockerCompose. |
+
+The schema only validates the `<package>@<version>` shape. Consumers
+(e.g. `adl-cli`) are responsible for resolving each entry against the
+sandbox's native package source.
+
+> If you need a package that *is* tied to a specific language, use that
+> language's [`vendor.deps` / `vendor.devdeps`](./language#vendor-config)
+> instead.

--- a/docs/reference/hooks.md
+++ b/docs/reference/hooks.md
@@ -1,0 +1,36 @@
+# `spec.hooks`
+
+Extension points where the generator should run user-supplied commands
+in addition to its built-in pipeline.
+
+```yaml
+spec:
+  hooks:
+    post:
+      - npm run lint
+      - go vet ./...
+      - go test ./...
+```
+
+## Fields
+
+| Field   | Type       | Required | Description                                                                                  |
+|---------|------------|:--------:|----------------------------------------------------------------------------------------------|
+| `post`  | `string[]` |          | Commands to run after code generation completes. Executed in order in the project directory. |
+
+Each entry is an opaque string — the schema doesn't parse it. The
+generator runs each command in a shell, in the order they appear, with
+the generated project as the working directory.
+
+## When to use this
+
+- Re-running formatters or linters after generation so the resulting
+  tree is shaped exactly the way your repo expects.
+- Running smoke tests so generation failures show up immediately, not
+  hours later in CI.
+- Triggering follow-up generation steps (e.g. `protoc`, `openapi-generator`,
+  `swagger-codegen`) that operate on the just-emitted files.
+
+If a hook needs a tool, declare that tool under
+[`spec.development.deps`](./development#deps) or under the relevant
+language's `vendor.devdeps` so the dev sandbox has it available.

--- a/docs/reference/hooks.md
+++ b/docs/reference/hooks.md
@@ -14,9 +14,9 @@ spec:
 
 ## Fields
 
-| Field   | Type       | Required | Description                                                                                  |
-|---------|------------|:--------:|----------------------------------------------------------------------------------------------|
-| `post`  | `string[]` |          | Commands to run after code generation completes. Executed in order in the project directory. |
+| Field  | Type       | Required | Description                                                                                  |
+| ------ | ---------- | :------: | -------------------------------------------------------------------------------------------- |
+| `post` | `string[]` |          | Commands to run after code generation completes. Executed in order in the project directory. |
 
 Each entry is an opaque string — the schema doesn't parse it. The
 generator runs each command in a shell, in the order they appear, with

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -8,17 +8,17 @@ The schema is JSON Schema Draft-07 and validates manifests with
 ## Manifest shape
 
 ```yaml
-apiVersion: adl.inference-gateway.com/v1   # required
-kind: Agent                                 # required
-metadata:                                   # required
+apiVersion: adl.inference-gateway.com/v1 # required
+kind: Agent # required
+metadata: # required
   name: string
   description: string
   version: x.y.z
   # optional: author, license, tags
-spec:                                       # required
-  capabilities: { ... }                     # required
-  server: { ... }                           # required
-  language: { ... }                         # required
+spec: # required
+  capabilities: { ... } # required
+  server: { ... } # required
+  language: { ... } # required
   # optional: card, agent, config, services, acronyms,
   #           tools, skills, artifacts, hooks, scm,
   #           development, deployment
@@ -26,32 +26,32 @@ spec:                                       # required
 
 ## Top-level
 
-| Field        | Required | Reference                            |
-|--------------|:--------:|--------------------------------------|
+| Field        | Required | Reference                               |
+| ------------ | :------: | --------------------------------------- |
 | `apiVersion` |    ✓     | [apiVersion / kind](./api-version-kind) |
 | `kind`       |    ✓     | [apiVersion / kind](./api-version-kind) |
-| `metadata`   |    ✓     | [metadata](./metadata)              |
-| `spec`       |    ✓     | [spec](./spec)                      |
+| `metadata`   |    ✓     | [metadata](./metadata)                  |
+| `spec`       |    ✓     | [spec](./spec)                          |
 
 ## `spec.*`
 
-| Field           | Required | Reference                                |
-|-----------------|:--------:|------------------------------------------|
-| `capabilities`  |    ✓     | [capabilities](./capabilities)           |
-| `card`          |          | [card](./card)                           |
-| `agent`         |          | [agent](./agent)                         |
-| `config`        |          | [config](./config)                       |
-| `services`      |          | [services](./services)                   |
-| `acronyms`      |          | [acronyms](./acronyms)                   |
-| `tools`         |          | [tools](./tools)                         |
-| `skills`        |          | [skills](./skills)                       |
-| `server`        |    ✓     | [server](./server)                       |
-| `language`      |    ✓     | [language](./language)                   |
-| `artifacts`     |          | [artifacts](./artifacts)                 |
-| `hooks`         |          | [hooks](./hooks)                         |
-| `scm`           |          | [scm](./scm)                             |
-| `development`   |          | [development](./development)             |
-| `deployment`    |          | [deployment](./deployment)               |
+| Field          | Required | Reference                      |
+| -------------- | :------: | ------------------------------ |
+| `capabilities` |    ✓     | [capabilities](./capabilities) |
+| `card`         |          | [card](./card)                 |
+| `agent`        |          | [agent](./agent)               |
+| `config`       |          | [config](./config)             |
+| `services`     |          | [services](./services)         |
+| `acronyms`     |          | [acronyms](./acronyms)         |
+| `tools`        |          | [tools](./tools)               |
+| `skills`       |          | [skills](./skills)             |
+| `server`       |    ✓     | [server](./server)             |
+| `language`     |    ✓     | [language](./language)         |
+| `artifacts`    |          | [artifacts](./artifacts)       |
+| `hooks`        |          | [hooks](./hooks)               |
+| `scm`          |          | [scm](./scm)                   |
+| `development`  |          | [development](./development)   |
+| `deployment`   |          | [deployment](./deployment)     |
 
 ## Appendix
 

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -1,0 +1,59 @@
+# Schema Reference — ADL v1
+
+This is the canonical reference for every field defined in
+[`schema/v1/schema.json`](https://github.com/inference-gateway/adl/blob/main/schema/v1/schema.json).
+The schema is JSON Schema Draft-07 and validates manifests with
+`apiVersion: adl.inference-gateway.com/v1`.
+
+## Manifest shape
+
+```yaml
+apiVersion: adl.inference-gateway.com/v1   # required
+kind: Agent                                 # required
+metadata:                                   # required
+  name: string
+  description: string
+  version: x.y.z
+  # optional: author, license, tags
+spec:                                       # required
+  capabilities: { ... }                     # required
+  server: { ... }                           # required
+  language: { ... }                         # required
+  # optional: card, agent, config, services, acronyms,
+  #           tools, skills, artifacts, hooks, scm,
+  #           development, deployment
+```
+
+## Top-level
+
+| Field        | Required | Reference                            |
+|--------------|:--------:|--------------------------------------|
+| `apiVersion` |    ✓     | [apiVersion / kind](./api-version-kind) |
+| `kind`       |    ✓     | [apiVersion / kind](./api-version-kind) |
+| `metadata`   |    ✓     | [metadata](./metadata)              |
+| `spec`       |    ✓     | [spec](./spec)                      |
+
+## `spec.*`
+
+| Field           | Required | Reference                                |
+|-----------------|:--------:|------------------------------------------|
+| `capabilities`  |    ✓     | [capabilities](./capabilities)           |
+| `card`          |          | [card](./card)                           |
+| `agent`         |          | [agent](./agent)                         |
+| `config`        |          | [config](./config)                       |
+| `services`      |          | [services](./services)                   |
+| `acronyms`      |          | [acronyms](./acronyms)                   |
+| `tools`         |          | [tools](./tools)                         |
+| `skills`        |          | [skills](./skills)                       |
+| `server`        |    ✓     | [server](./server)                       |
+| `language`      |    ✓     | [language](./language)                   |
+| `artifacts`     |          | [artifacts](./artifacts)                 |
+| `hooks`         |          | [hooks](./hooks)                         |
+| `scm`           |          | [scm](./scm)                             |
+| `development`   |          | [development](./development)             |
+| `deployment`    |          | [deployment](./deployment)               |
+
+## Appendix
+
+- [License identifiers](./license-identifiers) — the accepted SPDX set
+  for `metadata.license` and `spec.skills[].license`.

--- a/docs/reference/language.md
+++ b/docs/reference/language.md
@@ -38,11 +38,11 @@ spec:
 
 ## Supported languages
 
-| Key          | Config object                  |
-|--------------|--------------------------------|
-| `go`         | [GoConfig](#go-config)         |
+| Key          | Config object                          |
+| ------------ | -------------------------------------- |
+| `go`         | [GoConfig](#go-config)                 |
 | `typescript` | [TypeScriptConfig](#typescript-config) |
-| `rust`       | [RustConfig](#rust-config)     |
+| `rust`       | [RustConfig](#rust-config)             |
 
 You can configure more than one — the generator will emit a project for
 each. This is useful when an agent ships as both a service (Go) and an
@@ -50,24 +50,24 @@ SDK (TypeScript, Rust).
 
 ## `go` {#go-config}
 
-| Field     | Type     | Required | Description                                                |
-|-----------|----------|:--------:|------------------------------------------------------------|
-| `module`  | `string` |    ✓     | Go module path (e.g. `github.com/company/agent`).          |
-| `version` | `string` |    ✓     | Go toolchain version (e.g. `"1.26"`).                      |
-| `vendor`  | `object` |          | Extra packages — see [VendorConfig](#vendor-config).       |
+| Field     | Type     | Required | Description                                          |
+| --------- | -------- | :------: | ---------------------------------------------------- |
+| `module`  | `string` |    ✓     | Go module path (e.g. `github.com/company/agent`).    |
+| `version` | `string` |    ✓     | Go toolchain version (e.g. `"1.26"`).                |
+| `vendor`  | `object` |          | Extra packages — see [VendorConfig](#vendor-config). |
 
 ## `typescript` {#typescript-config}
 
-| Field         | Type     | Required | Description                                                     |
-|---------------|----------|:--------:|-----------------------------------------------------------------|
-| `packageName` | `string` |    ✓     | npm package name (kebab-case or scoped: `@org/name`).           |
-| `nodeVersion` | `string` |    ✓     | Node major version (e.g. `"20"`).                               |
-| `vendor`      | `object` |          | Extra packages — see [VendorConfig](#vendor-config).            |
+| Field         | Type     | Required | Description                                           |
+| ------------- | -------- | :------: | ----------------------------------------------------- |
+| `packageName` | `string` |    ✓     | npm package name (kebab-case or scoped: `@org/name`). |
+| `nodeVersion` | `string` |    ✓     | Node major version (e.g. `"20"`).                     |
+| `vendor`      | `object` |          | Extra packages — see [VendorConfig](#vendor-config).  |
 
 ## `rust` {#rust-config}
 
 | Field         | Type       | Required | Description                                                     |
-|---------------|------------|:--------:|-----------------------------------------------------------------|
+| ------------- | ---------- | :------: | --------------------------------------------------------------- |
 | `packageName` | `string`   |    ✓     | Cargo crate name.                                               |
 | `version`     | `string`   |    ✓     | Crate version (e.g. `"0.1.0"`).                                 |
 | `edition`     | `string`   |    ✓     | Rust edition (e.g. `"2021"`).                                   |
@@ -89,10 +89,10 @@ vendor:
     - <package>@<version>
 ```
 
-| Field      | Type       | Description                                                 |
-|------------|------------|-------------------------------------------------------------|
-| `deps`     | `string[]` | Runtime/production dependencies.                            |
-| `devdeps`  | `string[]` | Development- and test-only dependencies.                    |
+| Field     | Type       | Description                              |
+| --------- | ---------- | ---------------------------------------- |
+| `deps`    | `string[]` | Runtime/production dependencies.         |
+| `devdeps` | `string[]` | Development- and test-only dependencies. |
 
 Each entry is a string of the form `<package>@<version>` using the
 target language's native package and version syntax. The schema only
@@ -100,12 +100,12 @@ validates the **shape** — language-native semantics (semver ranges,
 scoped npm packages, Go module paths, etc.) are intentionally not
 constrained further.
 
-| Language     | Example entry                          |
-|--------------|----------------------------------------|
-| Go           | `github.com/google/uuid@v1.6.0`        |
-| TypeScript   | `zod@3.23.0`                           |
+| Language            | Example entry                   |
+| ------------------- | ------------------------------- |
+| Go                  | `github.com/google/uuid@v1.6.0` |
+| TypeScript          | `zod@3.23.0`                    |
 | TypeScript (scoped) | `"@types/node@20.11.0"`         |
-| Rust         | `tokio@1.36.0`                         |
+| Rust                | `tokio@1.36.0`                  |
 
 Consumers (e.g. `adl-cli`) translate these into the language's lockfile
 or manifest format (`go.mod`, `package.json`, `Cargo.toml`).

--- a/docs/reference/language.md
+++ b/docs/reference/language.md
@@ -1,0 +1,115 @@
+# `spec.language`
+
+Which target language(s) the generator should produce. **At least one**
+language must be configured (`minProperties: 1`).
+
+```yaml
+spec:
+  language:
+    go:
+      module: github.com/company/customer-support-agent
+      version: "1.26"
+      vendor:
+        deps:
+          - github.com/google/uuid@v1.6.0
+        devdeps:
+          - github.com/stretchr/testify@v1.9.0
+    typescript:
+      packageName: customer-support-agent
+      nodeVersion: "20"
+      vendor:
+        deps:
+          - zod@3.23.0
+        devdeps:
+          - vitest@1.6.0
+          - "@types/node@20.11.0"
+    rust:
+      packageName: customer-support-agent
+      version: "0.1.0"
+      edition: "2021"
+      features:
+        - server
+      vendor:
+        deps:
+          - tokio@1.36.0
+        devdeps:
+          - mockall@0.12.1
+```
+
+## Supported languages
+
+| Key          | Config object                  |
+|--------------|--------------------------------|
+| `go`         | [GoConfig](#go-config)         |
+| `typescript` | [TypeScriptConfig](#typescript-config) |
+| `rust`       | [RustConfig](#rust-config)     |
+
+You can configure more than one — the generator will emit a project for
+each. This is useful when an agent ships as both a service (Go) and an
+SDK (TypeScript, Rust).
+
+## `go` {#go-config}
+
+| Field     | Type     | Required | Description                                                |
+|-----------|----------|:--------:|------------------------------------------------------------|
+| `module`  | `string` |    ✓     | Go module path (e.g. `github.com/company/agent`).          |
+| `version` | `string` |    ✓     | Go toolchain version (e.g. `"1.26"`).                      |
+| `vendor`  | `object` |          | Extra packages — see [VendorConfig](#vendor-config).       |
+
+## `typescript` {#typescript-config}
+
+| Field         | Type     | Required | Description                                                     |
+|---------------|----------|:--------:|-----------------------------------------------------------------|
+| `packageName` | `string` |    ✓     | npm package name (kebab-case or scoped: `@org/name`).           |
+| `nodeVersion` | `string` |    ✓     | Node major version (e.g. `"20"`).                               |
+| `vendor`      | `object` |          | Extra packages — see [VendorConfig](#vendor-config).            |
+
+## `rust` {#rust-config}
+
+| Field         | Type       | Required | Description                                                     |
+|---------------|------------|:--------:|-----------------------------------------------------------------|
+| `packageName` | `string`   |    ✓     | Cargo crate name.                                               |
+| `version`     | `string`   |    ✓     | Crate version (e.g. `"0.1.0"`).                                 |
+| `edition`     | `string`   |    ✓     | Rust edition (e.g. `"2021"`).                                   |
+| `features`    | `string[]` |          | Cargo feature list to enable by default in the generated crate. |
+| `vendor`      | `object`   |          | Extra packages — see [VendorConfig](#vendor-config).            |
+
+## `vendor` {#vendor-config}
+
+Every language config accepts an optional `vendor` block to declare
+extra packages on top of whatever the generator pulls in by default.
+Useful for testing libraries, linters, mock generators, or any runtime
+package the scaffolding doesn't ship by default.
+
+```yaml
+vendor:
+  deps:
+    - <package>@<version>
+  devdeps:
+    - <package>@<version>
+```
+
+| Field      | Type       | Description                                                 |
+|------------|------------|-------------------------------------------------------------|
+| `deps`     | `string[]` | Runtime/production dependencies.                            |
+| `devdeps`  | `string[]` | Development- and test-only dependencies.                    |
+
+Each entry is a string of the form `<package>@<version>` using the
+target language's native package and version syntax. The schema only
+validates the **shape** — language-native semantics (semver ranges,
+scoped npm packages, Go module paths, etc.) are intentionally not
+constrained further.
+
+| Language     | Example entry                          |
+|--------------|----------------------------------------|
+| Go           | `github.com/google/uuid@v1.6.0`        |
+| TypeScript   | `zod@3.23.0`                           |
+| TypeScript (scoped) | `"@types/node@20.11.0"`         |
+| Rust         | `tokio@1.36.0`                         |
+
+Consumers (e.g. `adl-cli`) translate these into the language's lockfile
+or manifest format (`go.mod`, `package.json`, `Cargo.toml`).
+
+> If you need a package that isn't tied to a specific language — `deno`,
+> `kubectl`, `terraform` — use [`spec.development.deps`](./development#deps)
+> instead.

--- a/docs/reference/license-identifiers.md
+++ b/docs/reference/license-identifiers.md
@@ -1,0 +1,42 @@
+# License identifiers
+
+The accepted set of values for `metadata.license` and
+`spec.skills[].license`. Both fields share the same enum, so the same
+identifier means the same thing whether it's applied to the agent as a
+whole or to an individual skill.
+
+## Accepted values
+
+| Identifier      | Notes                                       |
+|-----------------|---------------------------------------------|
+| `MIT`           | Permissive                                  |
+| `Apache-2.0`    | Permissive, patent grant                    |
+| `BSD-2-Clause`  | Permissive                                  |
+| `BSD-3-Clause`  | Permissive                                  |
+| `GPL-2.0`       | Copyleft                                    |
+| `GPL-3.0`       | Copyleft                                    |
+| `LGPL-2.1`      | Weak copyleft                               |
+| `LGPL-3.0`      | Weak copyleft                               |
+| `MPL-2.0`       | Weak copyleft                               |
+| `ISC`           | Permissive                                  |
+| `CC0-1.0`       | Public domain dedication                    |
+| `CC-BY-4.0`     | Creative Commons, attribution               |
+| `CC-BY-SA-4.0`  | Creative Commons, attribution + share-alike |
+| `Unlicense`     | Public domain dedication                    |
+| `Proprietary`   | Closed-source / all rights reserved         |
+
+## Rules of the road
+
+- **One identifier, not an expression.** SPDX expressions such as
+  `MIT OR Apache-2.0` are **not** currently accepted; a single
+  identifier only.
+- **Mirrored in skill frontmatter.** For skills, the `license` value
+  mirrors the `license` field in the skill's `SKILL.md` frontmatter so
+  the licence travels with the playbook regardless of where it's
+  consumed.
+- **`LICENSE` file is optional.** Shipping a separate `LICENSE` file
+  alongside `SKILL.md` is not enforced by the schema — consumers MAY
+  include one in the skill's source directory if their distribution
+  channel expects it.
+- **Additive growth.** New identifiers may be added in future
+  **minor** versions of the schema; existing manifests stay valid.

--- a/docs/reference/license-identifiers.md
+++ b/docs/reference/license-identifiers.md
@@ -7,23 +7,23 @@ whole or to an individual skill.
 
 ## Accepted values
 
-| Identifier      | Notes                                       |
-|-----------------|---------------------------------------------|
-| `MIT`           | Permissive                                  |
-| `Apache-2.0`    | Permissive, patent grant                    |
-| `BSD-2-Clause`  | Permissive                                  |
-| `BSD-3-Clause`  | Permissive                                  |
-| `GPL-2.0`       | Copyleft                                    |
-| `GPL-3.0`       | Copyleft                                    |
-| `LGPL-2.1`      | Weak copyleft                               |
-| `LGPL-3.0`      | Weak copyleft                               |
-| `MPL-2.0`       | Weak copyleft                               |
-| `ISC`           | Permissive                                  |
-| `CC0-1.0`       | Public domain dedication                    |
-| `CC-BY-4.0`     | Creative Commons, attribution               |
-| `CC-BY-SA-4.0`  | Creative Commons, attribution + share-alike |
-| `Unlicense`     | Public domain dedication                    |
-| `Proprietary`   | Closed-source / all rights reserved         |
+| Identifier     | Notes                                       |
+| -------------- | ------------------------------------------- |
+| `MIT`          | Permissive                                  |
+| `Apache-2.0`   | Permissive, patent grant                    |
+| `BSD-2-Clause` | Permissive                                  |
+| `BSD-3-Clause` | Permissive                                  |
+| `GPL-2.0`      | Copyleft                                    |
+| `GPL-3.0`      | Copyleft                                    |
+| `LGPL-2.1`     | Weak copyleft                               |
+| `LGPL-3.0`     | Weak copyleft                               |
+| `MPL-2.0`      | Weak copyleft                               |
+| `ISC`          | Permissive                                  |
+| `CC0-1.0`      | Public domain dedication                    |
+| `CC-BY-4.0`    | Creative Commons, attribution               |
+| `CC-BY-SA-4.0` | Creative Commons, attribution + share-alike |
+| `Unlicense`    | Public domain dedication                    |
+| `Proprietary`  | Closed-source / all rights reserved         |
 
 ## Rules of the road
 

--- a/docs/reference/metadata.md
+++ b/docs/reference/metadata.md
@@ -5,15 +5,15 @@ optional.
 
 ```yaml
 metadata:
-  name: customer-support           # required
-  description: ...                  # required
-  version: "1.0.0"                  # required
-  author:                           # optional
+  name: customer-support # required
+  description: ... # required
+  version: "1.0.0" # required
+  author: # optional
     name: Acme Corp
     email: agents@acme.example
     url: https://acme.example
-  license: Apache-2.0               # optional
-  tags:                             # optional
+  license: Apache-2.0 # optional
+  tags: # optional
     - support
     - customer-service
 ```
@@ -56,9 +56,9 @@ are not currently accepted by the pattern.
 ```yaml
 metadata:
   author:
-    name: Acme Corp                  # required when author is present
-    email: agents@acme.example       # optional, format: email
-    url: https://acme.example        # optional, format: uri
+    name: Acme Corp # required when author is present
+    email: agents@acme.example # optional, format: email
+    url: https://acme.example # optional, format: uri
 ```
 
 Attribution and contact for whoever publishes the agent. Surfaces in

--- a/docs/reference/metadata.md
+++ b/docs/reference/metadata.md
@@ -1,0 +1,100 @@
+# `metadata`
+
+Identifying information about the agent. Three required fields, three
+optional.
+
+```yaml
+metadata:
+  name: customer-support           # required
+  description: ...                  # required
+  version: "1.0.0"                  # required
+  author:                           # optional
+    name: Acme Corp
+    email: agents@acme.example
+    url: https://acme.example
+  license: Apache-2.0               # optional
+  tags:                             # optional
+    - support
+    - customer-service
+```
+
+## `metadata.name`
+
+- **Type:** `string`
+- **Required:** yes
+- **Pattern:** `^[a-z0-9-]+$` — lowercase letters, digits, and hyphens only.
+
+The agent's canonical identifier. Generators turn this into package and
+service names, so the kebab-case constraint is enforced for portability
+across languages and runtimes.
+
+## `metadata.description`
+
+- **Type:** `string`
+- **Required:** yes
+
+A one-line summary of the agent. Surfaces in registries, README files,
+and generated documentation. Keep it short and behaviour-focused
+("Handles customer inquiries", not "An agent built with ADL").
+
+## `metadata.version`
+
+- **Type:** `string`
+- **Required:** yes
+- **Pattern:** `^\d+\.\d+\.\d+$` — semantic versioning `MAJOR.MINOR.PATCH`.
+
+The agent's own version, independent of the schema version. Bump it
+when you change the agent's behaviour. Pre-release suffixes (`-rc.1`)
+are not currently accepted by the pattern.
+
+## `metadata.author`
+
+- **Type:** `object`
+- **Required:** no
+- **Required sub-fields when present:** `name`
+
+```yaml
+metadata:
+  author:
+    name: Acme Corp                  # required when author is present
+    email: agents@acme.example       # optional, format: email
+    url: https://acme.example        # optional, format: uri
+```
+
+Attribution and contact for whoever publishes the agent. Surfaces in
+registries and the generated project's documentation. `additionalProperties`
+are not allowed — only `name`, `email`, and `url`.
+
+## `metadata.license`
+
+- **Type:** `string`
+- **Required:** no
+- **Allowed values:** SPDX identifiers, or `Proprietary`.
+
+```yaml
+metadata:
+  license: Apache-2.0
+```
+
+The licence the **agent** is distributed under. Mirrors the enum used by
+`spec.skills[].license`, so the same accepted set applies at both levels.
+See [License identifiers](./license-identifiers) for the full table.
+
+> SPDX expressions like `MIT OR Apache-2.0` are **not** currently
+> accepted — a single identifier only.
+
+## `metadata.tags`
+
+- **Type:** `string[]`
+- **Required:** no
+
+Discoverability tags for the agent (e.g. `calendar`, `automation`).
+Consumers may merge these with tool- and skill-level tags when indexing
+or building a search experience over a registry.
+
+```yaml
+metadata:
+  tags:
+    - support
+    - customer-service
+```

--- a/docs/reference/scm.md
+++ b/docs/reference/scm.md
@@ -18,15 +18,15 @@ spec:
 
 ## Fields
 
-| Field             | Type      | Constraint                          | Description                                                                        |
-|-------------------|-----------|-------------------------------------|------------------------------------------------------------------------------------|
-| `provider`        | `string`  | enum: `github`, `gitlab`, `bitbucket` | The SCM provider hosting the repository.                                         |
-| `url`             | `string`  | —                                   | Full URL of the repository.                                                        |
-| `github_app`      | `boolean` | —                                   | Generate GitHub App configuration (e.g. permissions, manifest).                    |
-| `issue_templates` | `boolean` | —                                   | Generate issue templates (bug report, feature request, …).                         |
-| `dependabot`      | `boolean` | —                                   | Generate a Dependabot config tracking the project's package ecosystems.            |
-| `ci`              | `boolean` | —                                   | Generate CI workflows (lint, test, build).                                         |
-| `cd`              | `boolean` | —                                   | Generate CD workflows (release, deploy).                                           |
+| Field             | Type      | Constraint                            | Description                                                             |
+| ----------------- | --------- | ------------------------------------- | ----------------------------------------------------------------------- |
+| `provider`        | `string`  | enum: `github`, `gitlab`, `bitbucket` | The SCM provider hosting the repository.                                |
+| `url`             | `string`  | —                                     | Full URL of the repository.                                             |
+| `github_app`      | `boolean` | —                                     | Generate GitHub App configuration (e.g. permissions, manifest).         |
+| `issue_templates` | `boolean` | —                                     | Generate issue templates (bug report, feature request, …).              |
+| `dependabot`      | `boolean` | —                                     | Generate a Dependabot config tracking the project's package ecosystems. |
+| `ci`              | `boolean` | —                                     | Generate CI workflows (lint, test, build).                              |
+| `cd`              | `boolean` | —                                     | Generate CD workflows (release, deploy).                                |
 
 Every field is optional. Omit the block entirely if the generator's
 defaults work for you, or supply only the toggles you care about.

--- a/docs/reference/scm.md
+++ b/docs/reference/scm.md
@@ -1,0 +1,36 @@
+# `spec.scm`
+
+Source-control configuration for the generated project — which provider
+it lives on, and which provider-specific scaffolding (CI, CD,
+Dependabot, issue templates, …) the generator should set up.
+
+```yaml
+spec:
+  scm:
+    provider: github
+    url: https://github.com/company/customer-support-agent
+    github_app: true
+    issue_templates: true
+    dependabot: true
+    ci: true
+    cd: true
+```
+
+## Fields
+
+| Field             | Type      | Constraint                          | Description                                                                        |
+|-------------------|-----------|-------------------------------------|------------------------------------------------------------------------------------|
+| `provider`        | `string`  | enum: `github`, `gitlab`, `bitbucket` | The SCM provider hosting the repository.                                         |
+| `url`             | `string`  | —                                   | Full URL of the repository.                                                        |
+| `github_app`      | `boolean` | —                                   | Generate GitHub App configuration (e.g. permissions, manifest).                    |
+| `issue_templates` | `boolean` | —                                   | Generate issue templates (bug report, feature request, …).                         |
+| `dependabot`      | `boolean` | —                                   | Generate a Dependabot config tracking the project's package ecosystems.            |
+| `ci`              | `boolean` | —                                   | Generate CI workflows (lint, test, build).                                         |
+| `cd`              | `boolean` | —                                   | Generate CD workflows (release, deploy).                                           |
+
+Every field is optional. Omit the block entirely if the generator's
+defaults work for you, or supply only the toggles you care about.
+
+> The `github_app` and `issue_templates` flags are most useful with
+> `provider: github`; consumers may interpret or ignore them when the
+> provider is `gitlab` or `bitbucket`.

--- a/docs/reference/server.md
+++ b/docs/reference/server.md
@@ -15,12 +15,12 @@ spec:
 
 ## Fields
 
-| Field    | Type      | Required | Constraint                   | Description                                                       |
-|----------|-----------|:--------:|------------------------------|-------------------------------------------------------------------|
-| `port`   | `integer` |    ✓     | `1` ≤ port ≤ `65535`         | TCP port the server binds to.                                     |
-| `scheme` | `string`  |          | —                            | URL scheme (`http`, `https`). Influences emitted URLs in code.    |
-| `debug`  | `boolean` |          | —                            | Enable verbose debug logging in generated code.                   |
-| `auth`   | `object`  |          | see [Auth](#spec-server-auth) | Authentication block.                                            |
+| Field    | Type      | Required | Constraint                    | Description                                                    |
+| -------- | --------- | :------: | ----------------------------- | -------------------------------------------------------------- |
+| `port`   | `integer` |    ✓     | `1` ≤ port ≤ `65535`          | TCP port the server binds to.                                  |
+| `scheme` | `string`  |          | —                             | URL scheme (`http`, `https`). Influences emitted URLs in code. |
+| `debug`  | `boolean` |          | —                             | Enable verbose debug logging in generated code.                |
+| `auth`   | `object`  |          | see [Auth](#spec-server-auth) | Authentication block.                                          |
 
 ## `spec.server.auth` {#spec-server-auth}
 
@@ -31,8 +31,8 @@ spec:
       enabled: true
 ```
 
-| Field     | Type      | Required | Description                                                                                    |
-|-----------|-----------|:--------:|------------------------------------------------------------------------------------------------|
+| Field     | Type      | Required | Description                                                                                                        |
+| --------- | --------- | :------: | ------------------------------------------------------------------------------------------------------------------ |
 | `enabled` | `boolean` |          | If `true`, the generator wires authentication into the server pipeline; if `false` or omitted, the server is open. |
 
 The schema deliberately keeps `auth` minimal in v1: it carries the

--- a/docs/reference/server.md
+++ b/docs/reference/server.md
@@ -1,0 +1,42 @@
+# `spec.server`
+
+Runtime HTTP server configuration. The only **required** field is
+`port`; the rest tune transport and auth.
+
+```yaml
+spec:
+  server:
+    port: 8080
+    scheme: https
+    debug: false
+    auth:
+      enabled: true
+```
+
+## Fields
+
+| Field    | Type      | Required | Constraint                   | Description                                                       |
+|----------|-----------|:--------:|------------------------------|-------------------------------------------------------------------|
+| `port`   | `integer` |    ✓     | `1` ≤ port ≤ `65535`         | TCP port the server binds to.                                     |
+| `scheme` | `string`  |          | —                            | URL scheme (`http`, `https`). Influences emitted URLs in code.    |
+| `debug`  | `boolean` |          | —                            | Enable verbose debug logging in generated code.                   |
+| `auth`   | `object`  |          | see [Auth](#spec-server-auth) | Authentication block.                                            |
+
+## `spec.server.auth` {#spec-server-auth}
+
+```yaml
+spec:
+  server:
+    auth:
+      enabled: true
+```
+
+| Field     | Type      | Required | Description                                                                                    |
+|-----------|-----------|:--------:|------------------------------------------------------------------------------------------------|
+| `enabled` | `boolean` |          | If `true`, the generator wires authentication into the server pipeline; if `false` or omitted, the server is open. |
+
+The schema deliberately keeps `auth` minimal in v1: it carries the
+intent (auth on / off), and the concrete mechanism (JWT, OIDC, mTLS,
+etc.) is the generator's territory. Future minor versions may extend
+this block with typed sub-configs as patterns stabilise across
+consumers.

--- a/docs/reference/services.md
+++ b/docs/reference/services.md
@@ -1,0 +1,60 @@
+# `spec.services`
+
+Declares external dependencies the agent's code should be wired against —
+databases, repositories, downstream clients, middleware. Each service
+gets an interface and a factory, which the generator turns into a typed
+dependency-injection seam in the target language.
+
+```yaml
+spec:
+  services:
+    customerRepo:
+      type: repository
+      interface: CustomerRepository
+      factory: NewPostgresCustomerRepository
+      description: Customer lookup by ID, backed by Postgres.
+    paymentsClient:
+      type: client
+      interface: PaymentsClient
+      factory: NewStripePaymentsClient
+      description: Thin wrapper around the Stripe SDK.
+```
+
+## Shape
+
+- **Type:** `object`
+- **Required:** no
+- **Structure:** keys are service names you pick; values are
+  [`Service`](#service-fields) objects.
+
+## Service fields
+
+Every service object requires all four fields below.
+
+| Field         | Type     | Constraint                                  | Description                                                  |
+|---------------|----------|---------------------------------------------|--------------------------------------------------------------|
+| `type`        | `string` | enum: `service`, `repository`, `client`, `middleware` | Broad role the service plays. Helps generators bucket DI.  |
+| `interface`   | `string` | pattern `^[a-zA-Z][a-zA-Z0-9_]*$`           | Interface/trait name the consumer code depends on.           |
+| `factory`     | `string` | pattern `^[a-zA-Z][a-zA-Z0-9_]*$`           | Factory function/constructor the runtime calls to build it.  |
+| `description` | `string` | —                                           | One-line explanation of what the service does.               |
+
+## `type` values
+
+| Value         | Use for                                                                  |
+|---------------|--------------------------------------------------------------------------|
+| `service`     | Domain services (business logic, multi-step workflows).                  |
+| `repository`  | Persistence and storage adapters.                                        |
+| `client`      | Wrappers around external APIs or SDKs.                                   |
+| `middleware`  | Cross-cutting concerns (auth, logging, tracing) installed into the pipeline. |
+
+## How it lands in generated code
+
+For a Go target, the example above would surface as interfaces named
+`CustomerRepository` and `PaymentsClient`, factory functions
+`NewPostgresCustomerRepository` and `NewStripePaymentsClient`, and a
+constructor that wires them together. The `type` is a hint to the
+generator about *where* to inject the dependency (e.g. into a repo
+layer vs the handler).
+
+You can refer to a service from a tool via the tool's [`inject`](./tools#inject)
+field, so the tool body receives a typed handle when it's invoked.

--- a/docs/reference/services.md
+++ b/docs/reference/services.md
@@ -31,21 +31,21 @@ spec:
 
 Every service object requires all four fields below.
 
-| Field         | Type     | Constraint                                  | Description                                                  |
-|---------------|----------|---------------------------------------------|--------------------------------------------------------------|
-| `type`        | `string` | enum: `service`, `repository`, `client`, `middleware` | Broad role the service plays. Helps generators bucket DI.  |
-| `interface`   | `string` | pattern `^[a-zA-Z][a-zA-Z0-9_]*$`           | Interface/trait name the consumer code depends on.           |
-| `factory`     | `string` | pattern `^[a-zA-Z][a-zA-Z0-9_]*$`           | Factory function/constructor the runtime calls to build it.  |
-| `description` | `string` | —                                           | One-line explanation of what the service does.               |
+| Field         | Type     | Constraint                                            | Description                                                 |
+| ------------- | -------- | ----------------------------------------------------- | ----------------------------------------------------------- |
+| `type`        | `string` | enum: `service`, `repository`, `client`, `middleware` | Broad role the service plays. Helps generators bucket DI.   |
+| `interface`   | `string` | pattern `^[a-zA-Z][a-zA-Z0-9_]*$`                     | Interface/trait name the consumer code depends on.          |
+| `factory`     | `string` | pattern `^[a-zA-Z][a-zA-Z0-9_]*$`                     | Factory function/constructor the runtime calls to build it. |
+| `description` | `string` | —                                                     | One-line explanation of what the service does.              |
 
 ## `type` values
 
-| Value         | Use for                                                                  |
-|---------------|--------------------------------------------------------------------------|
-| `service`     | Domain services (business logic, multi-step workflows).                  |
-| `repository`  | Persistence and storage adapters.                                        |
-| `client`      | Wrappers around external APIs or SDKs.                                   |
-| `middleware`  | Cross-cutting concerns (auth, logging, tracing) installed into the pipeline. |
+| Value        | Use for                                                                      |
+| ------------ | ---------------------------------------------------------------------------- |
+| `service`    | Domain services (business logic, multi-step workflows).                      |
+| `repository` | Persistence and storage adapters.                                            |
+| `client`     | Wrappers around external APIs or SDKs.                                       |
+| `middleware` | Cross-cutting concerns (auth, logging, tracing) installed into the pipeline. |
 
 ## How it lands in generated code
 
@@ -53,7 +53,7 @@ For a Go target, the example above would surface as interfaces named
 `CustomerRepository` and `PaymentsClient`, factory functions
 `NewPostgresCustomerRepository` and `NewStripePaymentsClient`, and a
 constructor that wires them together. The `type` is a hint to the
-generator about *where* to inject the dependency (e.g. into a repo
+generator about _where_ to inject the dependency (e.g. into a repo
 layer vs the handler).
 
 You can refer to a service from a tool via the tool's [`inject`](./tools#inject)

--- a/docs/reference/skills.md
+++ b/docs/reference/skills.md
@@ -1,0 +1,102 @@
+# `spec.skills`
+
+Markdown playbooks injected into the agent's system prompt at startup.
+Sourced from the skills registry or scaffolded blank with `bare: true`.
+
+```yaml
+spec:
+  skills:
+    - id: incident-response
+      bare: true
+      name: incident-response
+      description: How to triage a paged production incident, draft an initial response, and notify stakeholders.
+      license: Apache-2.0
+      tags:
+        - operations
+        - incident
+```
+
+If you're new to skills, read [Tools vs Skills](/guide/tools-vs-skills)
+first — it explains *when* you want a skill instead of a tool.
+
+## Shape
+
+- **Type:** array of [`Skill`](#skill-fields) objects.
+- **Required:** no
+
+## Skill fields
+
+| Field         | Type       | Required | Description                                                                                                |
+|---------------|------------|:--------:|------------------------------------------------------------------------------------------------------------|
+| `id`          | `string`   |    ✓     | Unique identifier. Pattern: `^[a-zA-Z0-9_][a-zA-Z0-9_-]*$` — kebab-case allowed.                          |
+| `version`     | `string`   |          | Version of the published skill to pull from the registry.                                                  |
+| `source`      | `string`   |          | Registry reference for a published skill.                                                                  |
+| `bare`        | `boolean`  |          | If `true`, scaffold an empty `SKILL.md` locally instead of pulling from the registry.                      |
+| `name`        | `string`   |          | Human-readable name. Typically matches `id`.                                                               |
+| `description` | `string`   |          | One-line summary of what the skill teaches.                                                                |
+| `license`     | `string`   |          | SPDX identifier or `Proprietary`. See [License identifiers](./license-identifiers).                        |
+| `tags`        | `string[]` |          | Discoverability tags.                                                                                      |
+
+`additionalProperties` are not allowed.
+
+## Two sources, one shape
+
+A skill is **either** pulled from the registry **or** scaffolded blank.
+The shape of the entry tells the generator which mode you want.
+
+### Pulled from the registry
+
+```yaml
+spec:
+  skills:
+    - id: prompt-engineering
+      source: registry/anthropic/prompt-engineering
+      version: 1.2.0
+      tags:
+        - prompting
+```
+
+The generator downloads the matching `SKILL.md` at build time and
+includes it in the project. Pin a `version` for reproducible builds.
+
+### Scaffolded blank (`bare: true`)
+
+```yaml
+spec:
+  skills:
+    - id: incident-response
+      bare: true
+      name: incident-response
+      description: How to triage a paged production incident...
+      license: Apache-2.0
+      tags: [operations, incident]
+```
+
+Use `bare: true` when the playbook is proprietary or one-off. The
+generator emits an empty `SKILL.md` shell with the right frontmatter,
+and you fill in the body. The skill's `license` (and the rest of the
+metadata) ends up in `SKILL.md`'s frontmatter, so it travels with the
+playbook.
+
+## Licensing
+
+Every skill **may** carry a `license`. The accepted enum is identical to
+the one for `metadata.license` — see
+[License identifiers](./license-identifiers) for the full table.
+
+The value mirrors the `license` field in the skill's `SKILL.md`
+frontmatter, so the licence travels with the playbook regardless of
+where it's consumed. Shipping a separate `LICENSE` file alongside
+`SKILL.md` is optional and not enforced by the schema — consumers MAY
+include one in the skill's source directory if their distribution
+channel expects it.
+
+> SPDX expressions like `MIT OR Apache-2.0` are not currently accepted.
+
+## How skills affect the agent at runtime
+
+At agent startup, the contents of each skill's `SKILL.md` are appended
+to the system prompt. The model therefore sees every skill as part of
+its initial instructions, and can follow them without any per-call
+overhead. This is the key trade-off vs. tools: skills are "free" at
+call time but expand the context window at startup.

--- a/docs/reference/skills.md
+++ b/docs/reference/skills.md
@@ -17,7 +17,7 @@ spec:
 ```
 
 If you're new to skills, read [Tools vs Skills](/guide/tools-vs-skills)
-first — it explains *when* you want a skill instead of a tool.
+first — it explains _when_ you want a skill instead of a tool.
 
 ## Shape
 
@@ -26,16 +26,16 @@ first — it explains *when* you want a skill instead of a tool.
 
 ## Skill fields
 
-| Field         | Type       | Required | Description                                                                                                |
-|---------------|------------|:--------:|------------------------------------------------------------------------------------------------------------|
-| `id`          | `string`   |    ✓     | Unique identifier. Pattern: `^[a-zA-Z0-9_][a-zA-Z0-9_-]*$` — kebab-case allowed.                          |
-| `version`     | `string`   |          | Version of the published skill to pull from the registry.                                                  |
-| `source`      | `string`   |          | Registry reference for a published skill.                                                                  |
-| `bare`        | `boolean`  |          | If `true`, scaffold an empty `SKILL.md` locally instead of pulling from the registry.                      |
-| `name`        | `string`   |          | Human-readable name. Typically matches `id`.                                                               |
-| `description` | `string`   |          | One-line summary of what the skill teaches.                                                                |
-| `license`     | `string`   |          | SPDX identifier or `Proprietary`. See [License identifiers](./license-identifiers).                        |
-| `tags`        | `string[]` |          | Discoverability tags.                                                                                      |
+| Field         | Type       | Required | Description                                                                           |
+| ------------- | ---------- | :------: | ------------------------------------------------------------------------------------- |
+| `id`          | `string`   |    ✓     | Unique identifier. Pattern: `^[a-zA-Z0-9_][a-zA-Z0-9_-]*$` — kebab-case allowed.      |
+| `version`     | `string`   |          | Version of the published skill to pull from the registry.                             |
+| `source`      | `string`   |          | Registry reference for a published skill.                                             |
+| `bare`        | `boolean`  |          | If `true`, scaffold an empty `SKILL.md` locally instead of pulling from the registry. |
+| `name`        | `string`   |          | Human-readable name. Typically matches `id`.                                          |
+| `description` | `string`   |          | One-line summary of what the skill teaches.                                           |
+| `license`     | `string`   |          | SPDX identifier or `Proprietary`. See [License identifiers](./license-identifiers).   |
+| `tags`        | `string[]` |          | Discoverability tags.                                                                 |
 
 `additionalProperties` are not allowed.
 
@@ -69,7 +69,9 @@ spec:
       name: incident-response
       description: How to triage a paged production incident...
       license: Apache-2.0
-      tags: [operations, incident]
+      tags:
+        - operations
+        - incident
 ```
 
 Use `bare: true` when the playbook is proprietary or one-off. The

--- a/docs/reference/spec.md
+++ b/docs/reference/spec.md
@@ -1,0 +1,51 @@
+# `spec`
+
+`spec` is where the agent is actually defined. It carries three required
+blocks and a long list of optional ones.
+
+## Required
+
+| Field           | Reference                                |
+|-----------------|------------------------------------------|
+| `capabilities`  | [capabilities](./capabilities)           |
+| `server`        | [server](./server)                       |
+| `language`      | [language](./language)                   |
+
+## Optional
+
+| Field           | Reference                                |
+|-----------------|------------------------------------------|
+| `card`          | [card](./card)                           |
+| `agent`         | [agent](./agent) — provider, model, prompt |
+| `config`        | [config](./config)                       |
+| `services`      | [services](./services)                   |
+| `acronyms`      | [acronyms](./acronyms)                   |
+| `tools`         | [tools](./tools)                         |
+| `skills`        | [skills](./skills)                       |
+| `artifacts`     | [artifacts](./artifacts)                 |
+| `hooks`         | [hooks](./hooks)                         |
+| `scm`           | [scm](./scm)                             |
+| `development`   | [development](./development)             |
+| `deployment`    | [deployment](./deployment)               |
+
+## Minimal valid `spec`
+
+The three required blocks together are enough to pass validation:
+
+```yaml
+spec:
+  capabilities:
+    streaming: true
+    pushNotifications: false
+    stateTransitionHistory: false
+  server:
+    port: 8080
+  language:
+    go:
+      module: github.com/example/agent
+      version: "1.26"
+```
+
+Everything beyond that is opt-in — pull in only what your agent actually
+uses. The schema doesn't penalise you for omitting capabilities you
+don't need; it penalises ambiguity.

--- a/docs/reference/spec.md
+++ b/docs/reference/spec.md
@@ -5,28 +5,28 @@ blocks and a long list of optional ones.
 
 ## Required
 
-| Field           | Reference                                |
-|-----------------|------------------------------------------|
-| `capabilities`  | [capabilities](./capabilities)           |
-| `server`        | [server](./server)                       |
-| `language`      | [language](./language)                   |
+| Field          | Reference                      |
+| -------------- | ------------------------------ |
+| `capabilities` | [capabilities](./capabilities) |
+| `server`       | [server](./server)             |
+| `language`     | [language](./language)         |
 
 ## Optional
 
-| Field           | Reference                                |
-|-----------------|------------------------------------------|
-| `card`          | [card](./card)                           |
-| `agent`         | [agent](./agent) — provider, model, prompt |
-| `config`        | [config](./config)                       |
-| `services`      | [services](./services)                   |
-| `acronyms`      | [acronyms](./acronyms)                   |
-| `tools`         | [tools](./tools)                         |
-| `skills`        | [skills](./skills)                       |
-| `artifacts`     | [artifacts](./artifacts)                 |
-| `hooks`         | [hooks](./hooks)                         |
-| `scm`           | [scm](./scm)                             |
-| `development`   | [development](./development)             |
-| `deployment`    | [deployment](./deployment)               |
+| Field         | Reference                                  |
+| ------------- | ------------------------------------------ |
+| `card`        | [card](./card)                             |
+| `agent`       | [agent](./agent) — provider, model, prompt |
+| `config`      | [config](./config)                         |
+| `services`    | [services](./services)                     |
+| `acronyms`    | [acronyms](./acronyms)                     |
+| `tools`       | [tools](./tools)                           |
+| `skills`      | [skills](./skills)                         |
+| `artifacts`   | [artifacts](./artifacts)                   |
+| `hooks`       | [hooks](./hooks)                           |
+| `scm`         | [scm](./scm)                               |
+| `development` | [development](./development)               |
+| `deployment`  | [deployment](./deployment)                 |
 
 ## Minimal valid `spec`
 

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -1,0 +1,152 @@
+# `spec.tools`
+
+Function-call entrypoints the agent can invoke at runtime. The
+generator turns each tool into a typed stub in the target language.
+
+```yaml
+spec:
+  tools:
+    - id: knowledge_search
+      name: knowledge_search
+      description: Search the company knowledge base
+      tags:
+        - knowledge
+        - search
+      schema:
+        type: object
+        properties:
+          query:
+            type: string
+            description: The search query
+        required:
+          - query
+```
+
+## Shape
+
+- **Type:** array of [`Tool`](#tool-fields) objects.
+- **Required:** no
+
+## Tool fields
+
+| Field         | Type       | Required | Description                                                                                  |
+|---------------|------------|:--------:|----------------------------------------------------------------------------------------------|
+| `id`          | `string`   |    ✓     | Unique identifier. Pattern: `^[a-zA-Z_][a-zA-Z0-9_]*$`. Becomes the symbol name in code.     |
+| `name`        | `string`   |          | Human-readable name. Required for user-defined tools (see below).                            |
+| `description` | `string`   |          | What the tool does. Required for user-defined tools.                                         |
+| `tags`        | `string[]` |          | Discoverability/grouping tags. Required for user-defined tools.                              |
+| `schema`      | `object`   |          | Free-form JSON Schema for the tool's input parameters. Required for user-defined tools.      |
+| `inject`      | `string[]` |          | Names of services from [`spec.services`](./services) to inject when the tool body is invoked. |
+
+`additionalProperties` are not allowed — anything outside this set fails
+validation.
+
+## User-defined vs. built-in tools
+
+The schema makes a deliberate split:
+
+- **User-defined tools** must supply `name`, `description`, `tags`, and
+  `schema` — that's how the generator knows what to wire up.
+- **Built-in tools** use reserved IDs (`read`, `bash`, `write`, `edit`,
+  …) and may omit those fields. The generator supplies the canonical
+  name, description, tags, and schema for built-ins.
+
+In practice: list a built-in by ID only when you want the generator to
+include it; list a user-defined tool with all four metadata fields when
+you want a new function in your agent.
+
+```yaml
+spec:
+  tools:
+    # Built-in: generator fills in the rest
+    - id: read
+    - id: bash
+
+    # User-defined: must spell everything out
+    - id: send_email
+      name: send_email
+      description: Send a transactional email via Postmark
+      tags: [communication, email]
+      schema:
+        type: object
+        properties:
+          to: { type: string, format: email }
+          subject: { type: string }
+          body: { type: string }
+        required: [to, subject, body]
+```
+
+## `schema`
+
+A free-form [JSON Schema](https://json-schema.org/) describing the
+tool's input parameters. The ADL schema deliberately doesn't constrain
+its contents — anything a JSON Schema validator accepts is allowed.
+Generators turn this into a typed input struct (Go), interface
+(TypeScript), or struct (Rust), and surface it to the LLM via the
+provider's function-calling API.
+
+### Common patterns
+
+```yaml
+# Simple required-string input
+schema:
+  type: object
+  properties:
+    query: { type: string }
+  required: [query]
+
+# Enum-constrained input
+schema:
+  type: object
+  properties:
+    region:
+      type: string
+      enum: [us-east-1, us-west-2, eu-west-1]
+  required: [region]
+
+# Nested object
+schema:
+  type: object
+  properties:
+    customer:
+      type: object
+      properties:
+        id: { type: string }
+        email: { type: string, format: email }
+      required: [id]
+  required: [customer]
+```
+
+## `inject` {#inject}
+
+A list of service names from [`spec.services`](./services) that should
+be wired into the tool body when the generator emits the stub. The
+generator uses these names to construct typed parameters or struct
+fields, so the tool implementation receives the dependencies directly
+rather than reaching out to a service locator.
+
+```yaml
+spec:
+  services:
+    customerRepo:
+      type: repository
+      interface: CustomerRepository
+      factory: NewPostgresCustomerRepository
+      description: ...
+  tools:
+    - id: get_customer
+      name: get_customer
+      description: Look up a customer by ID
+      tags: [customer]
+      schema:
+        type: object
+        properties:
+          id: { type: string }
+        required: [id]
+      inject:
+        - customerRepo
+```
+
+Each entry must match the pattern
+`^[a-zA-Z_][a-zA-Z0-9_]*(\.[a-zA-Z_][a-zA-Z0-9_]*)*$` — a single
+identifier or a dotted path (`foo.bar.baz`) for sub-references.

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -29,13 +29,13 @@ spec:
 
 ## Tool fields
 
-| Field         | Type       | Required | Description                                                                                  |
-|---------------|------------|:--------:|----------------------------------------------------------------------------------------------|
-| `id`          | `string`   |    ✓     | Unique identifier. Pattern: `^[a-zA-Z_][a-zA-Z0-9_]*$`. Becomes the symbol name in code.     |
-| `name`        | `string`   |          | Human-readable name. Required for user-defined tools (see below).                            |
-| `description` | `string`   |          | What the tool does. Required for user-defined tools.                                         |
-| `tags`        | `string[]` |          | Discoverability/grouping tags. Required for user-defined tools.                              |
-| `schema`      | `object`   |          | Free-form JSON Schema for the tool's input parameters. Required for user-defined tools.      |
+| Field         | Type       | Required | Description                                                                                   |
+| ------------- | ---------- | :------: | --------------------------------------------------------------------------------------------- |
+| `id`          | `string`   |    ✓     | Unique identifier. Pattern: `^[a-zA-Z_][a-zA-Z0-9_]*$`. Becomes the symbol name in code.      |
+| `name`        | `string`   |          | Human-readable name. Required for user-defined tools (see below).                             |
+| `description` | `string`   |          | What the tool does. Required for user-defined tools.                                          |
+| `tags`        | `string[]` |          | Discoverability/grouping tags. Required for user-defined tools.                               |
+| `schema`      | `object`   |          | Free-form JSON Schema for the tool's input parameters. Required for user-defined tools.       |
 | `inject`      | `string[]` |          | Names of services from [`spec.services`](./services) to inject when the tool body is invoked. |
 
 `additionalProperties` are not allowed — anything outside this set fails
@@ -66,14 +66,19 @@ spec:
     - id: send_email
       name: send_email
       description: Send a transactional email via Postmark
-      tags: [communication, email]
+      tags:
+        - communication
+        - email
       schema:
         type: object
         properties:
           to: { type: string, format: email }
           subject: { type: string }
           body: { type: string }
-        required: [to, subject, body]
+        required:
+          - to
+          - subject
+          - body
 ```
 
 ## `schema`
@@ -93,7 +98,8 @@ schema:
   type: object
   properties:
     query: { type: string }
-  required: [query]
+  required:
+    - query
 
 # Enum-constrained input
 schema:
@@ -101,8 +107,12 @@ schema:
   properties:
     region:
       type: string
-      enum: [us-east-1, us-west-2, eu-west-1]
-  required: [region]
+      enum:
+        - us-east-1
+        - us-west-2
+        - eu-west-1
+  required:
+    - region
 
 # Nested object
 schema:
@@ -113,8 +123,10 @@ schema:
       properties:
         id: { type: string }
         email: { type: string, format: email }
-      required: [id]
-  required: [customer]
+      required:
+        - id
+  required:
+    - customer
 ```
 
 ## `inject` {#inject}
@@ -137,12 +149,14 @@ spec:
     - id: get_customer
       name: get_customer
       description: Look up a customer by ID
-      tags: [customer]
+      tags:
+        - customer
       schema:
         type: object
         properties:
           id: { type: string }
-        required: [id]
+        required:
+          - id
       inject:
         - customerRepo
 ```


### PR DESCRIPTION
Closes #18

Scaffolds a Vite-powered static site generator (VitePress) under `./docs/` to serve as the long-form documentation home for ADL at https://adl.inference-gateway.com/v1/.

## What's included

- **Guide** (`docs/guide/`) — Introduction, Getting Started, Tools vs Skills, Versioning
- **Schema Reference** (`docs/reference/`) — one page per top-level field and every `spec.*` block, plus a license-identifiers appendix
- **Examples** (`docs/examples/`) — minimal, customer-support, multi-language manifests
- `docs/.vitepress/config.ts` — `base: '/v1/'`, full nav + sidebar, local search, edit-on-GitHub, sitemap
- `docs/public/CNAME` — `adl.inference-gateway.com` for Pages custom-domain persistence
- Root `README.md` — adds a docs badge and a dedicated Documentation section

## Follow-up needed by a maintainer

1. Add a `.github/workflows/deploy-docs.yml` workflow (reference snippet in `docs/README.md`) — the bot can't touch files under `.github/workflows/`.
2. Enable GitHub Pages with GitHub Actions as the source and set `adl.inference-gateway.com` as the custom domain + DNS.
3. Open the cross-repo follow-up issue in the inference-gateway docs project to avoid duplicated docs.

## Test plan

- [ ] `cd docs && npm install && npm run build` completes without errors
- [ ] `npm run preview` renders the home page, guide, reference, and examples sections
- [ ] All internal links resolve (sidebar entries match file paths)
- [ ] After the deploy workflow is added and Pages is configured, the site serves from https://adl.inference-gateway.com/v1/

Generated with [Claude Code](https://claude.ai/code)