### PR TITLE
ci(claude): restore valid effort level and fix node-version input

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -75,7 +75,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6.4.0
         with:
-          version: "lts/*"
+          node-version: "lts/*"
 
       - name: Install maintainer skill
         run: |
@@ -113,7 +113,7 @@ jobs:
           base_branch: main
           branch_prefix: ${{ steps.prefix.outputs.value }}
           claude_args: |
-            --effort ultracode
+            --effort max
             --model claude-opus-4-8
             --allowedTools "Bash(task:*),Bash(node:*),Bash(gh:*),Bash(git:*),mcp__playwright,mcp__context7"
           prompt: |


### PR DESCRIPTION
## Summary

The `@claude` workflow has been failing on every invocation. Run
[26686716573](https://github.com/inference-gateway/adl/actions/runs/26686716573/job/78656102638)
shows the **Run Claude Code** step exiting with code 1 ~0.24s after the CLI spawns — before any work.

**Root cause:** the recent "standardize workflow" change (`c9863ab`) set `claude_args` to
`--effort ultracode`. `ultracode` is **not** a valid effort level — the `claude` CLI validates
`--effort` at argument-parse time and rejects anything outside `low | medium | high | xhigh | max`:

```
error: option '--effort <level>' argument 'ultracode' is invalid. It must be one of: low, medium, high, xhigh, max
```

This PR restores `--effort max` (the previously-working, deliberately-set value — see `cf8e0b0`).
`--model claude-opus-4-8` is valid and left unchanged.

## Also fixed

The `Setup Node.js` step used the invalid input key `version:` instead of `node-version:`, which
GitHub flagged as `Unexpected input(s) 'version'`. The key is corrected so Node LTS is actually
pinned.

## Verification

- Reproduced locally: `claude --effort ultracode …` exits 1 with the error above; `claude --effort max …` exits 0.
- `claude.yml` parses cleanly.
- After merge: comment `@claude` on an issue and confirm the run reaches Claude and the
  "Unexpected input" annotation is gone.

## Cross-repo impact

`--effort ultracode` was copied into the standardized `claude.yml` across the org (~30 repos), so
**every `@claude` bot is currently broken** by the same one-line bug. This PR fixes `adl` first;
the identical `--effort` fix should be rolled out to the remaining repos as a follow-up.