### PR TITLE
feat: allow configuring GitHub App secret names for claudecode and infer orchestrators

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,6 +344,14 @@ experience for an agent project:
   Multiple orchestrators can be enabled at once if a project wants to
   ship configuration for more than one.
 
+  The `claudecode` and `infer` orchestrators additionally accept
+  `appIdSecret` and `appPrivateKeySecret`, the names of the repository
+  secrets holding the GitHub App client ID and private key used by the
+  generated workflows. They default to `CLAUDE_APP_ID` /
+  `CLAUDE_APP_PRIVATE_KEY` and `INFER_APP_ID` / `INFER_APP_PRIVATE_KEY`
+  respectively; set them when your organization uses different secret
+  names.
+
 - `spec.development.deps` declares extra packages to install into the
   development sandbox itself (flox, devcontainer, dockerCompose) on top
   of whatever the generator pulls in by default. Use this for

--- a/schema/v1/schema.json
+++ b/schema/v1/schema.json
@@ -604,7 +604,17 @@
       "description": "Provision Anthropic's Claude Code coding agent inside the sandbox.",
       "required": ["enabled"],
       "properties": {
-        "enabled": { "type": "boolean" }
+        "enabled": { "type": "boolean" },
+        "appIdSecret": {
+          "type": "string",
+          "description": "Name of the repository secret holding the GitHub App client ID used by the generated Claude Code workflow.",
+          "default": "CLAUDE_APP_ID"
+        },
+        "appPrivateKeySecret": {
+          "type": "string",
+          "description": "Name of the repository secret holding the GitHub App private key used by the generated Claude Code workflow.",
+          "default": "CLAUDE_APP_PRIVATE_KEY"
+        }
       }
     },
     "CodexConfig": {
@@ -636,7 +646,17 @@
       "description": "Provision the Inference Gateway 'infer' coding agent inside the sandbox.",
       "required": ["enabled"],
       "properties": {
-        "enabled": { "type": "boolean" }
+        "enabled": { "type": "boolean" },
+        "appIdSecret": {
+          "type": "string",
+          "description": "Name of the repository secret holding the GitHub App client ID used by the generated infer workflow.",
+          "default": "INFER_APP_ID"
+        },
+        "appPrivateKeySecret": {
+          "type": "string",
+          "description": "Name of the repository secret holding the GitHub App private key used by the generated infer workflow.",
+          "default": "INFER_APP_PRIVATE_KEY"
+        }
       }
     },
     "FloxConfig": {


### PR DESCRIPTION
## What

Adds optional `appIdSecret` and `appPrivateKeySecret` string fields to `ClaudeCodeConfig` and `InferConfig` under `spec.development.ai.orchestrators`. They name the repository secrets holding the GitHub App client ID and private key used by the generated workflows.

Defaults:
- claudecode: `CLAUDE_APP_ID` / `CLAUDE_APP_PRIVATE_KEY`
- infer: `INFER_APP_ID` / `INFER_APP_PRIVATE_KEY`

## Why

adl-cli generated workflows currently hardcode the secret names (`APP_ID` / `APP_PRIVATE_KEY`). Organizations often have their own secret naming conventions or multiple GitHub Apps, so the names must be configurable from the manifest. The Claude Code workflow is also gaining a GitHub App token step so the PRs it opens trigger CI, which needs its own secret pair.

## Impact

- Backwards-compatible additive change within schema v1.
- Consumer follow-up in `inference-gateway/adl-cli`: bump `ADL_SCHEMA_VERSION`, regenerate types, and read these fields in `ai-claude-code.yaml.tmpl` and `ai-infer.yaml.tmpl`.

## Verification

`task compile` passes (schema valid, Draft-07).