### PR TITLE
feat: allow configuring GitHub App secret names for the release workflow

### DIFF
--- a/docs/reference/scm.md
+++ b/docs/reference/scm.md
@@ -23,6 +23,8 @@ spec:
 | `provider`        | `string`  | enum: `github`, `gitlab`, `bitbucket` | The SCM provider hosting the repository.                                |
 | `url`             | `string`  | -                                     | Full URL of the repository.                                             |
 | `github_app`      | `boolean` | -                                     | Generate GitHub App configuration (e.g. permissions, manifest).         |
+| `app_id_secret`   | `string`  | default: `RELEASER_APP_ID`            | Repository secret name holding the GitHub App client ID used by the generated release (CD) workflow. |
+| `app_private_key_secret` | `string` | default: `RELEASER_APP_PRIVATE_KEY` | Repository secret name holding the GitHub App private key used by the generated release (CD) workflow. |
 | `issue_templates` | `boolean` | -                                     | Generate issue templates (bug report, feature request, …).              |
 | `dependabot`      | `boolean` | -                                     | Generate a Dependabot config tracking the project's package ecosystems. |
 | `ci`              | `boolean` | -                                     | Generate CI workflows (lint, test, build).                              |

--- a/docs/reference/scm.md
+++ b/docs/reference/scm.md
@@ -18,17 +18,17 @@ spec:
 
 ## Fields
 
-| Field             | Type      | Constraint                            | Description                                                             |
-| ----------------- | --------- | ------------------------------------- | ----------------------------------------------------------------------- |
-| `provider`        | `string`  | enum: `github`, `gitlab`, `bitbucket` | The SCM provider hosting the repository.                                |
-| `url`             | `string`  | -                                     | Full URL of the repository.                                             |
-| `github_app`      | `boolean` | -                                     | Generate GitHub App configuration (e.g. permissions, manifest).         |
-| `app_id_secret`   | `string`  | default: `RELEASER_APP_ID`            | Repository secret name holding the GitHub App client ID used by the generated release (CD) workflow. |
-| `app_private_key_secret` | `string` | default: `RELEASER_APP_PRIVATE_KEY` | Repository secret name holding the GitHub App private key used by the generated release (CD) workflow. |
-| `issue_templates` | `boolean` | -                                     | Generate issue templates (bug report, feature request, …).              |
-| `dependabot`      | `boolean` | -                                     | Generate a Dependabot config tracking the project's package ecosystems. |
-| `ci`              | `boolean` | -                                     | Generate CI workflows (lint, test, build).                              |
-| `cd`              | `boolean` | -                                     | Generate CD workflows (release, deploy).                                |
+| Field                    | Type      | Constraint                            | Description                                                                                            |
+| ------------------------ | --------- | ------------------------------------- | ------------------------------------------------------------------------------------------------------ |
+| `provider`               | `string`  | enum: `github`, `gitlab`, `bitbucket` | The SCM provider hosting the repository.                                                               |
+| `url`                    | `string`  | -                                     | Full URL of the repository.                                                                            |
+| `github_app`             | `boolean` | -                                     | Generate GitHub App configuration (e.g. permissions, manifest).                                        |
+| `app_id_secret`          | `string`  | default: `RELEASER_APP_ID`            | Repository secret name holding the GitHub App client ID used by the generated release (CD) workflow.   |
+| `app_private_key_secret` | `string`  | default: `RELEASER_APP_PRIVATE_KEY`   | Repository secret name holding the GitHub App private key used by the generated release (CD) workflow. |
+| `issue_templates`        | `boolean` | -                                     | Generate issue templates (bug report, feature request, …).                                             |
+| `dependabot`             | `boolean` | -                                     | Generate a Dependabot config tracking the project's package ecosystems.                                |
+| `ci`                     | `boolean` | -                                     | Generate CI workflows (lint, test, build).                                                             |
+| `cd`                     | `boolean` | -                                     | Generate CD workflows (release, deploy).                                                               |
 
 Every field is optional. Omit the block entirely if the generator's
 defaults work for you, or supply only the toggles you care about.

--- a/schema/v1/schema.json
+++ b/schema/v1/schema.json
@@ -550,6 +550,16 @@
         },
         "url": { "type": "string" },
         "github_app": { "type": "boolean" },
+        "app_id_secret": {
+          "type": "string",
+          "description": "Name of the repository secret holding the GitHub App client ID used by the generated release (CD) workflow when github_app is enabled.",
+          "default": "RELEASER_APP_ID"
+        },
+        "app_private_key_secret": {
+          "type": "string",
+          "description": "Name of the repository secret holding the GitHub App private key used by the generated release (CD) workflow when github_app is enabled.",
+          "default": "RELEASER_APP_PRIVATE_KEY"
+        },
         "issue_templates": { "type": "boolean" },
         "dependabot": { "type": "boolean" },
         "ci": { "type": "boolean" },


### PR DESCRIPTION
## What

Adds optional `app_id_secret` and `app_private_key_secret` string fields to `spec.scm`, naming the repository secrets holding the GitHub App client ID and private key used by the generated release (CD) workflow when `github_app` is enabled. Defaults: `RELEASER_APP_ID` / `RELEASER_APP_PRIVATE_KEY`.

## Why

Same rationale as #112 for the claudecode/infer orchestrators: adl-cli's generated cd.yml hardcodes `BOT_GH_APP_ID` / `BOT_GH_APP_PRIVATE_KEY`; the names must be configurable from the manifest, with sensible per-purpose defaults.

## Impact

- Backwards-compatible additive change within schema v1.
- Consumer follow-up in inference-gateway/adl-cli: bump `ADL_SCHEMA_VERSION`, regenerate types, read the fields in cd.yaml.tmpl.

## Verification

`task compile` passes (schema valid, Draft-07). docs/reference/scm.md updated.