### PR TITLE
feat: add optional path to spec.examples entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -468,20 +468,24 @@ full field list.
 capabilities. Each entry has a `title` and a `description`; consumers
 (e.g. `adl-cli`) use these to render an "Examples" section in the
 generated README.md, linking each example to a scratchpad or playground
-for the agent.
+for the agent. An entry may also carry an optional `path` naming a
+directory relative to the generated project root; consumers seed a stub
+README there once (never overwriting user edits) and link the Examples
+table entry to it.
 
 ```yaml
 spec:
   examples:
     - title: Basic chat
       description: A simple question-and-answer interaction
+      path: examples/basic-chat
     - title: Tool use
       description: Booking a flight through the booking tool
 ```
 
 `spec.examples` is optional and additive - manifests that omit it stay
-valid. Both `title` and `description` are required on every entry, and
-no other fields are accepted.
+valid. Both `title` and `description` are required on every entry;
+`path` is the only other accepted field.
 
 ## Consumers
 

--- a/schema/v1/schema.json
+++ b/schema/v1/schema.json
@@ -159,7 +159,7 @@
     },
     "Example": {
       "type": "object",
-      "description": "A single example entry. 'title' is the human-readable heading shown in the generated README's Examples section; 'description' explains what the example demonstrates.",
+      "description": "A single example entry. 'title' is the human-readable heading shown in the generated README's Examples section; 'description' explains what the example demonstrates; 'path' optionally names a directory where the consumer scaffolds the example once.",
       "required": ["title", "description"],
       "additionalProperties": false,
       "properties": {
@@ -170,6 +170,10 @@
         "description": {
           "type": "string",
           "description": "One- or two-sentence explanation of what the example demonstrates."
+        },
+        "path": {
+          "type": "string",
+          "description": "Optional directory for the example, relative to the generated project root (e.g. 'examples/basic-chat'). Consumers seed a stub README there once and never overwrite it, and link the Examples table entry to it."
         }
       }
     },


### PR DESCRIPTION
An example entry may now name a directory relative to the generated project root. Consumers (adl-cli) seed a stub README there once, never overwrite user edits, and link the generated Examples table entry to it - mirroring how spec.documentation.pages paths are seeded. Additive within v1: title and description stay the only required fields.