### PR TITLE
ci: add manual workflow to sync schema to adl-cli

### DIFF
--- a/.github/workflows/sync-adl-cli.yml
+++ b/.github/workflows/sync-adl-cli.yml
@@ -1,0 +1,63 @@
+---
+name: Sync adl-cli
+
+# Manually dispatch a schema-sync event to inference-gateway/adl-cli.
+# adl-cli's sync-schema workflow bumps its pinned schema tag, runs `task generate`,
+# and opens a PR with the result. Manual trigger only.
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Schema git tag to sync (e.g. v0.22.0). Defaults to the latest adl release.'
+        required: false
+        type: string
+
+permissions: {}
+
+jobs:
+  dispatch:
+    name: Dispatch schema-sync to adl-cli
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/create-github-app-token@v3.2.0
+        id: app-token
+        with:
+          client-id: ${{ secrets.RELEASER_APP_ID }}
+          private-key: ${{ secrets.RELEASER_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: |
+            adl-cli
+
+      - name: Resolve schema ref
+        id: ref
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          INPUT_REF: ${{ inputs.ref }}
+        run: |
+          REF="$INPUT_REF"
+          if [ -z "$REF" ]; then
+            REF=$(gh release view --repo ${{ github.repository }} --json tagName -q .tagName)
+          fi
+          echo "ref=$REF" >> "$GITHUB_OUTPUT"
+          echo "Resolved schema ref: $REF"
+
+      - name: Dispatch schema-sync
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          REF: ${{ steps.ref.outputs.ref }}
+        run: |
+          gh api repos/${{ github.repository_owner }}/adl-cli/dispatches \
+            -f event_type=schema-sync \
+            -F client_payload[ref]="$REF"
+
+      - name: Job summary
+        env:
+          REF: ${{ steps.ref.outputs.ref }}
+        run: |
+          {
+            echo "## Dispatched schema-sync to adl-cli"
+            echo ""
+            echo "- Schema ref: \`$REF\`"
+            echo "- Watch: https://github.com/${{ github.repository_owner }}/adl-cli/actions"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/sync-adl-cli.yml
+++ b/.github/workflows/sync-adl-cli.yml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:
     inputs:
       ref:
-        description: 'Schema git tag to sync (e.g. v0.22.0). Defaults to the latest adl release.'
+        description: "Schema git tag to sync (e.g. v0.22.0). Defaults to the latest adl release."
         required: false
         type: string
 


### PR DESCRIPTION
Adds a manual `workflow_dispatch` workflow (`.github/workflows/sync-adl-cli.yml`) that dispatches a `schema-sync` `repository_dispatch` event to `inference-gateway/adl-cli`.

- Optional `ref` input (schema git tag to sync); defaults to the latest `adl` release tag.
- Mints a cross-repo GitHub App token scoped to `adl-cli` via the existing `RELEASER_APP_ID` / `RELEASER_APP_PRIVATE_KEY` secrets.
- Writes a job summary linking to adl-cli Actions.

Downstream (separate PR in adl-cli): a `sync-schema.yml` workflow listens on `repository_dispatch: [schema-sync]`, bumps the Taskfile `SCHEMA_REF` var, runs `task generate`, and opens a PR via `peter-evans/create-pull-request@v8.1.1`.