### PR TITLE
feat(docs): migrate site hosting from GitHub Pages to Cloudflare Workers

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,21 +7,23 @@ on:
       - main
     paths:
       - "docs/**"
+      - "schema/v1/schema.json"
       - ".github/workflows/deploy.yml"
   workflow_dispatch:
 
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
 concurrency:
   group: pages
   cancel-in-progress: false
 
 jobs:
-  build:
+  deploy:
     runs-on: ubuntu-24.04
+    environment:
+      name: production
+      url: https://adl.inference-gateway.com
     steps:
       - uses: actions/checkout@v7.0.1
       - uses: actions/setup-node@v7
@@ -31,17 +33,13 @@ jobs:
         working-directory: docs
       - run: npm run build
         working-directory: docs
-      - uses: actions/configure-pages@v6.0.0
-      - uses: actions/upload-pages-artifact@v5.0.0
-        with:
-          path: docs/.vitepress/dist
-
-  deploy:
-    needs: build
-    runs-on: ubuntu-24.04
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    steps:
-      - id: deployment
-        uses: actions/deploy-pages@v5
+      - name: Add schema to site
+        run: |
+          mkdir -p docs/.vitepress/dist/schemas/agent
+          cp schema/v1/schema.json docs/.vitepress/dist/schemas/agent/v1
+      - name: Deploy to Cloudflare Workers
+        run: npx wrangler@4 deploy
+        working-directory: docs
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/.prettierignore
+++ b/.prettierignore
@@ -2,6 +2,7 @@ CHANGELOG.md
 AGENTS.md
 CLAUDE.md
 .infer
+.flox
 docs/.vitepress
 .github/workflows/claude.yml
 .github/workflows/infer.yml

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 .vitepress/dist
 .vitepress/cache
+.wrangler

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from "vitepress";
 
 // VitePress configuration for the ADL documentation site.
 //
-// The site is published at https://adl.inference-gateway.com/ via GitHub Pages.
+// The site is published at https://adl.inference-gateway.com/ via Cloudflare Workers.
 export default defineConfig({
   base: "/",
   lang: "en-US",

--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,1 +1,0 @@
-adl.inference-gateway.com

--- a/docs/public/CNAME
+++ b/docs/public/CNAME
@@ -1,1 +1,0 @@
-adl.inference-gateway.com

--- a/docs/public/_headers
+++ b/docs/public/_headers
@@ -1,0 +1,2 @@
+/schemas/agent/v1
+  Content-Type: application/json

--- a/docs/wrangler.jsonc
+++ b/docs/wrangler.jsonc
@@ -1,0 +1,14 @@
+{
+  "name": "adl-docs",
+  "compatibility_date": "2026-08-18",
+  "assets": {
+    "directory": ".vitepress/dist",
+    "not_found_handling": "404-page",
+  },
+  "routes": [{ "pattern": "adl.inference-gateway.com", "custom_domain": true }],
+  "preview_urls": true,
+  "observability": {
+    "enabled": true,
+    "logs": { "enabled": true, "invocation_logs": true },
+  },
+}


### PR DESCRIPTION
## What

Migrates the VitePress docs site (`docs/`, https://adl.inference-gateway.com) from GitHub Pages to Cloudflare Workers static assets, mirroring the `inference-gateway/docs` setup (docs#566).

- `docs/wrangler.jsonc`: assets-only Worker, custom domain `adl.inference-gateway.com`
- `.github/workflows/deploy.yml`: single job, `npm ci && npm run build` then `npx wrangler@4 deploy`; also triggers on `schema/v1/schema.json`
- The site now serves `schema/v1/schema.json` at its declared `$id` URL `/schemas/agent/v1` (copied into dist at build time, `Content-Type: application/json` via `docs/public/_headers`) — previously that URL was a 404
- Removed GitHub Pages `CNAME` files

Prod deploy only; PR previews deliberately skipped — add later by copying `preview.yml` from `inference-gateway/docs` if wanted.

## Schema impact

None. `schema/v1/schema.json` untouched; its `$id` simply resolves now.

## One-time steps after merge (maintainer)

1. Add repo secrets `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID` (same token pattern as `inference-gateway/docs`)
2. Run the Deploy workflow (`workflow_dispatch`); `custom_domain: true` provisions `adl.inference-gateway.com` — remove any conflicting DNS record pointing `adl` at GitHub Pages if wrangler complains
3. Unpublish GitHub Pages in repo settings

## Validated

- `task compile` and `task format:check` pass
- Local build + `wrangler dev`: `/` 200, `/schemas/agent/v1` 200 with `application/json`, unknown path returns the 404 page
