### PR TITLE
feat(schema): validate reserved built-in tool configs under spec.config.tools

### DIFF
--- a/schema/v1/schema.json
+++ b/schema/v1/schema.json
@@ -81,6 +81,9 @@
         "agent": { "$ref": "#/definitions/Agent" },
         "config": {
           "type": "object",
+          "properties": {
+            "tools": { "$ref": "#/definitions/ToolsConfig" }
+          },
           "additionalProperties": {
             "type": "object",
             "additionalProperties": true
@@ -387,6 +390,74 @@
           "pattern": "^[a-zA-Z][a-zA-Z0-9_]*$"
         },
         "description": { "type": "string" }
+      }
+    },
+    "ToolsConfig": {
+      "type": "object",
+      "description": "Per-tool configuration under spec.config.tools. The five reserved built-in tool IDs (read, bash, write, edit, fetch) have typed shapes validated here; any other key is a user-defined tool's config and stays free-form.",
+      "properties": {
+        "read": { "$ref": "#/definitions/ReadToolConfig" },
+        "bash": { "$ref": "#/definitions/BashToolConfig" },
+        "write": { "$ref": "#/definitions/WriteToolConfig" },
+        "edit": { "$ref": "#/definitions/EditToolConfig" },
+        "fetch": { "$ref": "#/definitions/FetchToolConfig" }
+      },
+      "additionalProperties": {
+        "type": "object",
+        "additionalProperties": true
+      }
+    },
+    "ReadToolConfig": {
+      "type": "object",
+      "description": "Configuration for the reserved read built-in tool.",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "max_lines": { "type": "integer", "minimum": 0 },
+        "allowed_roots": { "type": "array", "items": { "type": "string" } }
+      }
+    },
+    "BashToolConfig": {
+      "type": "object",
+      "description": "Configuration for the reserved bash built-in tool.",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "whitelist": { "type": "array", "items": { "type": "string" } },
+        "timeout_seconds": { "type": "integer", "minimum": 0 },
+        "working_dir": { "type": "string" }
+      }
+    },
+    "WriteToolConfig": {
+      "type": "object",
+      "description": "Configuration for the reserved write built-in tool.",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "allowed_roots": { "type": "array", "items": { "type": "string" } }
+      }
+    },
+    "EditToolConfig": {
+      "type": "object",
+      "description": "Configuration for the reserved edit built-in tool.",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "allowed_roots": { "type": "array", "items": { "type": "string" } }
+      }
+    },
+    "FetchToolConfig": {
+      "type": "object",
+      "description": "Configuration for the reserved fetch built-in tool. When allowed_domains is empty, internal/private addresses are denied by default (SSRF guard) unless allow_internal is true.",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "allowed_domains": { "type": "array", "items": { "type": "string" } },
+        "max_bytes": { "type": "integer", "minimum": 0 },
+        "timeout_seconds": { "type": "integer", "minimum": 0 },
+        "download_dir": { "type": "string" },
+        "allow_downloads": { "type": "boolean" },
+        "allow_internal": { "type": "boolean" }
       }
     },
     "Tool": {


### PR DESCRIPTION
Resolves #165

## Summary

Defines typed shapes with `additionalProperties: false` for the five reserved built-in tool ids (`read`, `bash`, `write`, `edit`, `fetch`) under `spec.config.tools`, via a new `ToolsConfig` definition. Field lists match the decoders in adl-cli's `internal/schema/builtin_config.go`, including the new `allow_internal` SSRF opt-out on fetch (inference-gateway/adl-cli#373).

Previously `spec.config` was fully free-form, so a misspelled key like `allow_internals` or `allowed_root` validated cleanly and silently did nothing. These fields now grant filesystem and network access under adl-cli's deny-by-default semantics, so a silently dropped key means an operator believes an allowlist is active when it is not.

Everything else stays free-form: other `spec.config` keys (service configs) and non-reserved tool ids under `spec.config.tools` (custom tool configs).

## Verification

- `task compile` (AJV draft-07) passes; `task format:check` clean
- All 20 example manifests in adl-cli's `examples/` validate against the new schema
- A manifest with `max_liness` under `spec.config.tools.read` now fails with `must NOT have additional properties` at `/spec/config/tools/read`

## Cross-repo impact

- **adl-cli**: after release, the Sync adl-cli workflow bumps `ADL_SCHEMA_VERSION` and reruns `task fetch-schema` + `task generate-types`; go-jsonschema will emit new types for the tool config shapes, and the generator's existing skip of the reserved `spec.config.tools` namespace for the Config struct is unaffected
- **docs**: adl.md / adl-cli.md may want a line noting reserved tool configs are now schema-validated