### PR TITLE
docs: describe the Cloudflare Workers deployment in docs/README.md

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -2,7 +2,7 @@
 
 This directory contains the [VitePress](https://vitepress.dev/) source for
 the ADL documentation site, published at
-**https://adl.inference-gateway.com/** via GitHub Pages.
+**https://adl.inference-gateway.com/** via Cloudflare Workers.
 
 The site is the long-form companion to the canonical schema at
 [`schema/v1/schema.json`](../schema/v1/schema.json). The schema validates;
@@ -41,12 +41,13 @@ docs/
 ├── .vitepress/
 │   └── config.ts          # VitePress site config (nav, sidebar, base path)
 ├── public/
-│   └── CNAME              # GitHub Pages custom domain (adl.inference-gateway.com)
+│   └── _headers           # Serves /schemas/agent/v1 as application/json
 ├── guide/                 # Conceptual guide pages
 ├── reference/             # Per-field schema reference
 ├── examples/              # Copy-pasteable ADL manifests
 ├── index.md               # Landing page (Hero + features)
 ├── package.json           # VitePress + Vue dev deps
+├── wrangler.jsonc         # Cloudflare Workers config (assets dir, custom domain)
 └── README.md              # This file
 ```
 
@@ -54,10 +55,14 @@ docs/
 
 The site is built and published by
 [`.github/workflows/deploy.yml`](../.github/workflows/deploy.yml) on every
-push to `main` that touches `docs/**`. GitHub Pages must be configured with
-the "GitHub Actions" build source (Settings → Pages). The custom domain
-`adl.inference-gateway.com` is preserved on each deploy via
-[`docs/public/CNAME`](./public/CNAME).
+push to `main` that touches `docs/**`, `schema/v1/schema.json`, or the
+workflow itself. The workflow runs `npm ci` and `npm run build`, copies
+`schema/v1/schema.json` into the build output so it is served at
+`/schemas/agent/v1` (the schema's declared `$id`), and deploys the static
+assets with `npx wrangler@4 deploy` using the `CLOUDFLARE_API_TOKEN` and
+`CLOUDFLARE_ACCOUNT_ID` repository secrets. The custom domain
+`adl.inference-gateway.com` is declared in
+[`docs/wrangler.jsonc`](./wrangler.jsonc).
 
 ## Contributing
 


### PR DESCRIPTION
## Summary

Docs-only fix for `docs/README.md`, which still described the pre-#164 hosting setup.

- The intro said the site is published "via GitHub Pages"; it is served by Cloudflare Workers since #164.
- The directory layout listed `public/CNAME` ("GitHub Pages custom domain"), a file that no longer exists (the link was dead), and omitted `wrangler.jsonc` and `public/_headers`, which are the files that now configure the deployment. The tree now shows those two with one-line descriptions.
- The "Deployment" section told maintainers to configure GitHub Pages with the "GitHub Actions" build source and said the custom domain is preserved via `docs/public/CNAME`. It now describes what `.github/workflows/deploy.yml` actually does: triggers on `docs/**`, `schema/v1/schema.json` and the workflow itself, runs `npm ci` and `npm run build`, copies the schema into the build output so it is served at `/schemas/agent/v1`, and deploys with `npx wrangler@4 deploy` using the `CLOUDFLARE_API_TOKEN` / `CLOUDFLARE_ACCOUNT_ID` secrets, with the custom domain declared in `docs/wrangler.jsonc`.

No schema changes. `docs/README.md` is excluded from the site build (`srcExclude` in `.vitepress/config.ts`), so nothing changes on the published site.

## Checks

- A scan of every relative link in the repo's markdown files (VitePress-style resolution) finds `./public/CNAME` was the only broken target; none remain.
- `npx prettier@3.8.3 --check docs/README.md` passes (same check as the pre-commit hook).
